### PR TITLE
Assigning temporary tags to sequence used in mafft and fastme (workaround for issue #24)

### DIFF
--- a/modules/fastme/main.nf
+++ b/modules/fastme/main.nf
@@ -22,6 +22,7 @@ process FASTME {
         -o temp.nwk \\
         -T $task.cpus
 
+    # Workaround for https://github.com/qcif/taxodactyl/issues/24
     # Rename the tree tips using the provided ID mapping file
     # sed with word boundaries to avoid partial matches
     awk -F'\t' '{ printf "s/\\\\<%s\\\\>/%s/g\\n", \$1, \$2 }' "$id_mapping_file" | sed -f - temp.nwk > $params.tree_nwk_filename

--- a/modules/mafft/align/main.nf
+++ b/modules/mafft/align/main.nf
@@ -20,6 +20,7 @@ process MAFFT_ALIGN {
     # Create the query folder if it doesn't exist
     mkdir -p $query_folder
 
+    # Workaround for https://github.com/qcif/taxodactyl/issues/24
     # Strip everything after the first space in header lines
     sed '/^>/s/ .*//' $candidate_fasta_file > stripped_${candidate_fasta_file}
 
@@ -54,8 +55,17 @@ process MAFFT_ALIGN {
         $query_folder/temp.fasta \\
         > $query_folder/temp.msa
 
-    # Replace HIT IDs with original sequence IDs in the alignment
-    awk -F'\t' '{ printf "s/\\\\<%s\\\\>/%s/g\\n", \$1, \$2 }' $query_folder/id_mapping.tsv | sed -f - $query_folder/temp.msa > $query_folder/$params.candidates_msa_filename
+    # Workaround for https://github.com/qcif/taxodactyl/issues/24
+    # Replace HIT IDs with original sequence IDs in the alignment,
+    # padding the original ID to 11 chars (or adding one space if longer)
+    awk -F'\t' '{
+        rep = \$2;
+        gsub("/", "\\/", rep);                     # escape any slashes in replacement
+        n = 11 - length(rep);
+        if (n > 0) rep = rep sprintf("%*s", n, "");# pad to 11 characters
+        else rep = rep " ";                        # otherwise add single trailing space
+        printf "s/\\\\<%s\\\\>[[:space:]]*/%s/g\\n", \$1, rep
+    }' $query_folder/id_mapping.tsv | sed -f - $query_folder/temp.msa > $query_folder/$params.candidates_msa_filename
 
     # Record the MAFFT version used for reproducibility
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
MAFFT and FastME truncate long RefSeq sequence IDs leading to loss of uniqueness.

Workaround:
1. 	Assign temporary tags
Replace each original sequence ID with a unique  tag in the FASTA file.
2. 	Create a mapping file
Store the relationship between each  and its original RefSeq ID.
3. 	Run alignment and tree-building
Use MAFFT and FastME safely, avoiding truncation issues.
4. 	Restore original IDs
After tree construction and alignment, use the mapping file to replace  tags with the correct RefSeq IDs.