### PR TITLE
Display relatives with same taxid in coverage report

### DIFF
--- a/scripts/src/coverage/fetch.py
+++ b/scripts/src/coverage/fetch.py
@@ -161,8 +161,8 @@ def _fetch_gb_records_for_species(species_names, locus):
             errors.append((taxid_to_species[taxid], exc))
 
     species_counts = {
-        taxid_to_species[taxid]: count
-        for taxid, count in results.items()
+        species: results.get(taxid, 0)
+        for species, taxid in taxids.items()
     }
     species_counts.update({
         species: 0

--- a/scripts/tests/test-data/metadata.csv
+++ b/scripts/tests/test-data/metadata.csv
@@ -1,5 +1,5 @@
 sample_id,locus,classification,preliminary_id,taxa_of_interest,country,host,sequencing_platform
-LC438549.1,COI,animalia,Asterias rubens,Asteridae|Acanthaster planci,Japan,driftwood,nanopore
+LC438549.1,COI,,Orthotospovirus,Asteridae|Acanthaster planci,Japan,driftwood,nanopore
 ON075825.1,COX1,animalia,Epinephelus,Epinephelus|Epinephelus awoara,China,fishing net,illumina
 PP466915.1,NA,animalia,Sitodiplosis,,,,nanopore
 JQ585746.1,COX1,animalia,Doradidae,Platydoras armatulus,China,fishing net,nanopore

--- a/scripts/tests/test-data/metadata.csv
+++ b/scripts/tests/test-data/metadata.csv
@@ -1,5 +1,5 @@
 sample_id,locus,classification,preliminary_id,taxa_of_interest,country,host,sequencing_platform
-LC438549.1,COI,,Orthotospovirus,Asteridae|Acanthaster planci,Japan,driftwood,nanopore
+LC438549.1,COI,animalia,Asterias rubens,Asteridae|Acanthaster planci,Japan,driftwood,nanopore
 ON075825.1,COX1,animalia,Epinephelus,Epinephelus|Epinephelus awoara,China,fishing net,illumina
 PP466915.1,NA,animalia,Sitodiplosis,,,,nanopore
 JQ585746.1,COX1,animalia,Doradidae,Platydoras armatulus,China,fishing net,nanopore


### PR DESCRIPTION
This would resolve #232

Currently some (virus) species returned by GBIF share the same taxid. That is, genbank regards them as the same species. This can be confusing in coverage reports, as it results in duplicate species names being silently excluded from the count and plots. This PR results in all species being displayed, with genbank records being counted against all GBIF names for that taxid.