### PR TITLE
Gbif throttle backoff

### DIFF
--- a/scripts/src/utils/config/config.py
+++ b/scripts/src/utils/config/config.py
@@ -386,6 +386,10 @@ class Config:
         return self.user_tempdir / ('throttle_' + self.sqlite_file)
 
     @property
+    def throttle_sqlite_global_path(self):
+        return self.tempdir / ('throttle_' + self.sqlite_file)
+
+    @property
     def cache_sqlite_path(self):
         return self.tempdir / ('cache_' + self.sqlite_file)
 

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -75,6 +75,8 @@ class Throttle:
     BACKOFF_DEBOUNCE_MS = 30_000  # 30s
     BACKOFF_EXPIRY_MS = 7_200_000  # 2 hours
     BACKOFF_MIN_RPS = 0.1
+    _await_exception_count = 0
+    _await_exception_msg = ""
 
     def __init__(
         self,
@@ -258,6 +260,7 @@ class Throttle:
                         conn.rollback()
 
                     except sqlite3.OperationalError as e:
+                        self._consider_await_exception(e)
                         logger.warning(
                             "OperationalError during throttle check:"
                             f" {e}. Retrying..."
@@ -276,6 +279,16 @@ class Throttle:
                     f"Awaiting throttle release for endpoint {self.name}"
                     f" for >{seconds_waited} seconds..."
                 )
+
+    def _consider_await_exception(self, exception):
+        """Raise if the same exception has occurred 5 times in a row."""
+        if self._await_exception_msg != str(exception):
+            self._await_exception_msg = str(exception)
+            self._await_exception_count = 0
+        self._await_exception_count += 1
+        if self._await_exception_count >= 5:
+            raise exception
+
 
     def _notify_429(self):
         """Record a 429 response and apply backoff if debounce has elapsed.

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -190,6 +190,8 @@ class Throttle:
             for attempt in range(max_retries):
                 try:
                     with self._get_connection() as conn:
+                        conn.execute("PRAGMA journal_mode=WAL;")
+                        conn.commit()
                         conn.execute(f"""
                             CREATE TABLE IF NOT EXISTS {self.table_name} (
                                 {self.FIELD_NAME} INTEGER
@@ -209,7 +211,6 @@ class Throttle:
                                 " VALUES (1, ?, 0)",
                                 (self.rps,)
                             )
-                        conn.execute("PRAGMA journal_mode=WAL;")
                         conn.commit()
                         break
                 except sqlite3.OperationalError as e:

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -2,7 +2,9 @@ import logging
 import random
 import sqlite3
 import time
+from dataclasses import dataclass
 from pprint import pformat
+from typing import Optional
 
 from .cache import FileLock
 from .config import Config
@@ -13,26 +15,43 @@ config = Config()
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class Endpoint:
+    """Configuration for a throttled API endpoint."""
+
+    name: str
+    requests_per_second: Optional[int] = None
+    requests_per_minute: Optional[int] = None
+    backoff_factor: Optional[int] = None
+
+    def __post_init__(self):
+        if not (self.requests_per_second or self.requests_per_minute):
+            raise ValueError(
+                "Endpoint must specify either 'requests_per_second'"
+                " or 'requests_per_minute'."
+            )
+
+
 class ENDPOINTS:
-    GBIF_SLOW = {
-        'requests_per_second': 1,
-        'name': 'gbif_slow',
-        'backoff_factor': 2,
-    }
-    GBIF_FAST = {
-        'requests_per_second': 10,
-        'name': 'gbif_fast',
-        'backoff_factor': 2,
-    }
-    ENTREZ = {
-        'requests_per_second': 10,
-        'name': 'entrez',
-    }
-    BOLD = {
-        'requests_per_second': 5,
-        'requests_per_minute': 50,
-        'name': 'bold',
-    }
+    GBIF_SLOW = Endpoint(
+        name='gbif_slow',
+        requests_per_second=1,
+        backoff_factor=2,
+    )
+    GBIF_FAST = Endpoint(
+        name='gbif_fast',
+        requests_per_second=10,
+        backoff_factor=2,
+    )
+    ENTREZ = Endpoint(
+        name='entrez',
+        requests_per_second=10,
+    )
+    BOLD = Endpoint(
+        name='bold',
+        requests_per_second=5,
+        requests_per_minute=50,
+    )
 
 
 class Throttle:
@@ -43,18 +62,6 @@ class Throttle:
     allow for request rates to be set per-service, and to for throttles to be
     managed independently.
 
-    The endpoint arg should be a dict of:
-        {
-          'requests_per_second': int,  # Max requests per second
-          // AND/OR
-          'requests_per_minute': int,  # Max requests per minute
-          'name': str,                 # Name to identify this endpoint
-          'backoff_factor': int,       # Optional. Divide RPS by this factor
-                                       # on each 429 response. 429s within a
-                                       # 10s window are debounced. Backoff
-                                       # state expires after 2 hours.
-        }
-
     To be conservative, the throttle will limit per-second requests in 2-second
     blocks and per-minute requests in 90-second blocks.
     """
@@ -62,21 +69,16 @@ class Throttle:
     FIELD_NAME = 'timestamp'
     PER_SECOND_BLOCK_MS = 2000
     PER_MINUTE_BLOCK_MS = 12000
-    BACKOFF_DEBOUNCE_MS = 10000
-    BACKOFF_EXPIRY_MS = 7200000
+    BACKOFF_DEBOUNCE_MS = 30_000  # 30s
+    BACKOFF_EXPIRY_MS = 7_200_000  # 2 hours
     BACKOFF_MIN_RPS = 0.1
 
     def __init__(
         self,
-        endpoint: dict,
+        endpoint: Endpoint,
     ):
-        self.rps = endpoint.get('requests_per_second')
-        self.rpm = endpoint.get('requests_per_minute')
-        if not (self.rps or self.rpm):
-            raise ValueError(
-                "Endpoint must specify either 'requests_per_second' or"
-                " 'requests_per_minute'."
-            )
+        self.rps = endpoint.requests_per_second
+        self.rpm = endpoint.requests_per_minute
         self.per_second_limit = bool(self.rps)
         self.per_minute_limit = bool(self.rpm)
         self.window_length_ms = (
@@ -84,9 +86,9 @@ class Throttle:
             if self.rpm
             else self.PER_SECOND_BLOCK_MS
         )
-        self.backoff_factor = endpoint.get('backoff_factor')
+        self.backoff_factor = endpoint.backoff_factor
         self.db_path = config.throttle_sqlite_path
-        self.name = endpoint['name']
+        self.name = endpoint.name
         self.table_name = f"throttle_{self.name}"
         self.backoff_table = f"backoff_{self.name}"
         self._initialize_db()

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -92,7 +92,7 @@ class Throttle:
         self.backoff_factor = endpoint.backoff_factor
         self.db_path = (
             config.throttle_sqlite_global_path
-            if self.endpoint.global_rate_limit
+            if endpoint.global_rate_limit
             else config.throttle_sqlite_path
         )
         self.name = endpoint.name

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -17,10 +17,12 @@ class ENDPOINTS:
     GBIF_SLOW = {
         'requests_per_second': 1,
         'name': 'gbif_slow',
+        'backoff_factor': 2,
     }
     GBIF_FAST = {
         'requests_per_second': 10,
         'name': 'gbif_fast',
+        'backoff_factor': 2,
     }
     ENTREZ = {
         'requests_per_second': 10,
@@ -47,6 +49,10 @@ class Throttle:
           // AND/OR
           'requests_per_minute': int,  # Max requests per minute
           'name': str,                 # Name to identify this endpoint
+          'backoff_factor': int,       # Optional. Divide RPS by this factor
+                                       # on each 429 response. 429s within a
+                                       # 10s window are debounced. Backoff
+                                       # state expires after 2 hours.
         }
 
     To be conservative, the throttle will limit per-second requests in 2-second
@@ -56,6 +62,9 @@ class Throttle:
     FIELD_NAME = 'timestamp'
     PER_SECOND_BLOCK_MS = 2000
     PER_MINUTE_BLOCK_MS = 12000
+    BACKOFF_DEBOUNCE_MS = 10000
+    BACKOFF_EXPIRY_MS = 7200000
+    BACKOFF_MIN_RPS = 0.1
 
     def __init__(
         self,
@@ -75,9 +84,11 @@ class Throttle:
             if self.rpm
             else self.PER_SECOND_BLOCK_MS
         )
+        self.backoff_factor = endpoint.get('backoff_factor')
         self.db_path = config.throttle_sqlite_path
         self.name = endpoint['name']
         self.table_name = f"throttle_{self.name}"
+        self.backoff_table = f"backoff_{self.name}"
         self._initialize_db()
 
     def __enter__(self):
@@ -133,7 +144,7 @@ class Throttle:
         return conn
 
     def _initialize_db(self):
-        """Create table for tracking request timestamps."""
+        """Create tables for tracking request timestamps and backoff."""
         if not self.db_path.exists():
             logger.info(
                 f"Creating throttle SQLite DB file: {self.db_path}"
@@ -175,6 +186,21 @@ class Throttle:
                                 {self.FIELD_NAME} INTEGER
                             )
                         """)
+                        if self.backoff_factor:
+                            conn.execute(f"""
+                                CREATE TABLE IF NOT EXISTS {self.backoff_table} (
+                                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                                    effective_rps REAL NOT NULL,
+                                    last_429_timestamp INTEGER NOT NULL
+                                )
+                            """)
+                            conn.execute(
+                                f"INSERT OR IGNORE INTO {self.backoff_table}"
+                                " (id, effective_rps, last_429_timestamp)"
+                                " VALUES (1, ?, 0)",
+                                (self.rps,)
+                            )
+                        conn.execute("PRAGMA journal_mode=WAL;")
                         conn.commit()
                         break
                 except sqlite3.OperationalError as e:
@@ -242,6 +268,77 @@ class Throttle:
                     f" for >{seconds_waited} seconds..."
                 )
 
+    def _notify_429(self):
+        """Record a 429 response and apply backoff if debounce has elapsed.
+
+        All 429s within BACKOFF_DEBOUNCE_MS are lumped together so that the
+        backoff factor is applied only once per debounce window.
+        """
+        if not self.backoff_factor:
+            return
+        try:
+            with sqlite3.connect(
+                self.db_path,
+                isolation_level=None,
+            ) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                now = int(time.time() * 1000)
+                row = conn.execute(
+                    f"SELECT effective_rps, last_429_timestamp"
+                    f" FROM {self.backoff_table}"
+                    " WHERE id = 1"
+                ).fetchone()
+                effective_rps, last_429_ts = row
+
+                if now - last_429_ts < self.BACKOFF_DEBOUNCE_MS:
+                    conn.rollback()
+                    return
+
+                new_rps = max(
+                    effective_rps / self.backoff_factor,
+                    self.BACKOFF_MIN_RPS,
+                )
+                conn.execute(
+                    f"UPDATE {self.backoff_table}"
+                    " SET effective_rps = ?,"
+                    " last_429_timestamp = ?"
+                    " WHERE id = 1",
+                    (new_rps, now),
+                )
+                conn.commit()
+                logger.warning(
+                    f"429 backoff applied for endpoint {self.name}:"
+                    f" RPS reduced from {effective_rps} to {new_rps}"
+                )
+        except sqlite3.OperationalError:
+            pass
+
+    def _get_effective_rps(self, conn):
+        """Read effective RPS from backoff table, resetting if expired."""
+        row = conn.execute(
+            f"SELECT effective_rps, last_429_timestamp"
+            f" FROM {self.backoff_table}"
+            " WHERE id = 1"
+        ).fetchone()
+        effective_rps, last_429_ts = row
+        now = int(time.time() * 1000)
+
+        if last_429_ts and now - last_429_ts > self.BACKOFF_EXPIRY_MS:
+            conn.execute(
+                f"UPDATE {self.backoff_table}"
+                " SET effective_rps = ?,"
+                " last_429_timestamp = 0"
+                " WHERE id = 1",
+                (self.rps,),
+            )
+            logger.info(
+                f"Backoff expired for endpoint {self.name}:"
+                f" RPS reset to {self.rps}"
+            )
+            return self.rps
+
+        return effective_rps
+
     def _within_request_limits(self, now, conn):
         """Check if the request limits are within the allowed range.
         This method uses a sliding window of timestamps to determine
@@ -279,9 +376,13 @@ class Throttle:
                 f"SELECT COUNT(*) FROM {self.table_name}"
             ).fetchone()[0]
 
+        rps_limit = self.rps
+        if self.backoff_factor and self.per_second_limit:
+            rps_limit = self._get_effective_rps(conn)
+
         within_per_second_limit = (
             not self.per_second_limit
-            or rps_observed < self.rps
+            or rps_observed < rps_limit
         )
         within_per_minute_limit = (
             not self.per_minute_limit
@@ -314,10 +415,18 @@ class Throttle:
                 sleep_seconds = 1
                 retries -= 1
                 if '429' in str(exc):
-                    sleep_seconds = 600
-                    logger.warning(
-                        "API rate limit exceeded. Waiting 10 minutes before"
-                        " next retry.")
+                    self._notify_429()
+                    if self.backoff_factor:
+                        sleep_seconds = 10
+                        logger.warning(
+                            "API rate limit exceeded for endpoint"
+                            f" {self.name}. Backoff applied,"
+                            " retrying in 10 seconds.")
+                    else:
+                        sleep_seconds = 600
+                        logger.warning(
+                            "API rate limit exceeded. Waiting"
+                            " 10 minutes before next retry.")
                     retries = config.max_api_retries
                 elif retries <= 0:
                     raise APIError(

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -167,12 +167,7 @@ class Throttle:
                         with self._get_connection(
                             setup_wal=False,
                         ) as conn:
-                            conn.execute(f"""
-                                CREATE TABLE IF NOT EXISTS {self.table_name} (
-                                    {self.FIELD_NAME} INTEGER
-                                )
-                            """)
-                            conn.commit()
+                            self._create_db_tables(conn)
                             break
                     except sqlite3.OperationalError as e:
                         if (
@@ -190,28 +185,7 @@ class Throttle:
             for attempt in range(max_retries):
                 try:
                     with self._get_connection() as conn:
-                        conn.execute("PRAGMA journal_mode=WAL;")
-                        conn.commit()
-                        conn.execute(f"""
-                            CREATE TABLE IF NOT EXISTS {self.table_name} (
-                                {self.FIELD_NAME} INTEGER
-                            )
-                        """)
-                        if self.backoff_factor:
-                            conn.execute(f"""
-                                CREATE TABLE IF NOT EXISTS {self.backoff_table} (
-                                    id INTEGER PRIMARY KEY CHECK (id = 1),
-                                    effective_rps REAL NOT NULL,
-                                    last_429_timestamp INTEGER NOT NULL
-                                )
-                            """)
-                            conn.execute(
-                                f"INSERT OR IGNORE INTO {self.backoff_table}"
-                                " (id, effective_rps, last_429_timestamp)"
-                                " VALUES (1, ?, 0)",
-                                (self.rps,)
-                            )
-                        conn.commit()
+                        self._create_db_tables(conn)
                         break
                 except sqlite3.OperationalError as e:
                     if (
@@ -221,6 +195,29 @@ class Throttle:
                         time.sleep(0.1 * (2 ** attempt))
                         continue
                     raise
+
+    def _create_db_tables(self, conn):
+        """Create necessary tables for throttling and backoff."""
+        conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS {self.table_name} (
+                {self.FIELD_NAME} INTEGER
+            )
+        """)
+        if self.backoff_factor:
+            conn.execute(f"""
+                CREATE TABLE IF NOT EXISTS {self.backoff_table} (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    effective_rps REAL NOT NULL,
+                    last_429_timestamp INTEGER NOT NULL
+                )
+            """)
+            conn.execute(
+                f"INSERT OR IGNORE INTO {self.backoff_table}"
+                " (id, effective_rps, last_429_timestamp)"
+                " VALUES (1, ?, 0)",
+                (self.rps,)
+            )
+        conn.commit()
 
     def _await_release(self):
         """Query sqlite DB for permission to send a request.
@@ -257,12 +254,14 @@ class Throttle:
                             conn.commit()
                             return
 
-                        # Rollback if the request limit is exceeded
+                        # The request limit has been exceeded
                         conn.rollback()
 
-                    except sqlite3.OperationalError:
-                        # Handle potential lock contention gracefully
-                        pass
+                    except sqlite3.OperationalError as e:
+                        logger.warning(
+                            "OperationalError during throttle check:"
+                            f" {e}. Retrying..."
+                        )
 
             except sqlite3.OperationalError as e:
                 raise sqlite3.OperationalError(

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -23,6 +23,7 @@ class Endpoint:
     requests_per_second: Optional[int] = None
     requests_per_minute: Optional[int] = None
     backoff_factor: Optional[int] = None
+    global_rate_limit: bool = False
 
     def __post_init__(self):
         if not (self.requests_per_second or self.requests_per_minute):
@@ -37,11 +38,13 @@ class ENDPOINTS:
         name='gbif_slow',
         requests_per_second=1,
         backoff_factor=2,
+        global_rate_limit=True,
     )
     GBIF_FAST = Endpoint(
         name='gbif_fast',
         requests_per_second=10,
         backoff_factor=2,
+        global_rate_limit=True,
     )
     ENTREZ = Endpoint(
         name='entrez',
@@ -87,7 +90,11 @@ class Throttle:
             else self.PER_SECOND_BLOCK_MS
         )
         self.backoff_factor = endpoint.backoff_factor
-        self.db_path = config.throttle_sqlite_path
+        self.db_path = (
+            config.throttle_sqlite_global_path
+            if self.endpoint.global_rate_limit
+            else config.throttle_sqlite_path
+        )
         self.name = endpoint.name
         self.table_name = f"throttle_{self.name}"
         self.backoff_table = f"backoff_{self.name}"


### PR DESCRIPTION
This implements a progressive backoff for GBIF request interval, so that when we get an "API rate limit exceeded" error, we slow down requests for the rest of the run to ensure we don't hit that again (every occurrence delays the workflow another 10 minutes).

> [!NOTE] 
> This conflicts with `azure-redis`, which refactors the throttle into SQLite/Redis backends.