### PR TITLE
Azure redis

### DIFF
--- a/.env.azure.sample
+++ b/.env.azure.sample
@@ -18,6 +18,11 @@ NODE_AGENT_SKU="batch.node.ubuntu 24.04"
 IMAGE_TAG=canonical:ubuntu-24_04-lts:server
 VM_SKU=Standard_L8as_v3
 VM_CPUS=8
+# Redis (distributed rate-limiting across concurrent workflow instances)
+THROTTLE_BACKEND=redis
+REDIS_HOST=daff-redis.australiaeast.cloudapp.azure.com
+REDIS_PORT=6379
+REDIS_PASSWORD="your-redis-password"
 
 # Nextflow Azure Configuration
 AZURE_BATCH_ACCOUNT_NAME=$BATCH_ACCOUNT

--- a/.env.azure.sample
+++ b/.env.azure.sample
@@ -18,18 +18,25 @@ NODE_AGENT_SKU="batch.node.ubuntu 24.04"
 IMAGE_TAG=canonical:ubuntu-24_04-lts:server
 VM_SKU=Standard_L8as_v3
 VM_CPUS=8
+
+CACHE_BACKEND=sqlite  # azure_blob for proper caching on Azure, requires the below:
+CACHE_AZURE_ACCOUNT_URL=https://<STORAGE_ACCOUNT_STD>.blob.core.windows.net
+CACHE_AZURE_CONNECTION_STRING=secret-connection-string
+CACHE_AZURE_CONTAINER=cache
+CACHE_AZURE_BLOB_PREFIX=taxodactyl/
+
 # Redis (distributed rate-limiting across concurrent workflow instances)
 THROTTLE_BACKEND=redis
-REDIS_HOST=daff-redis.australiaeast.cloudapp.azure.com
+REDIS_HOST=<vm-name>.<region>.cloudapp.azure.com
 REDIS_PORT=6379
 REDIS_PASSWORD="your-redis-password"
 
 # Nextflow Azure Configuration
 AZURE_BATCH_ACCOUNT_NAME=$BATCH_ACCOUNT
-AZURE_BATCH_ACCESS_KEY="your-batch-account-access-key"
 AZURE_BATCH_ENDPOINT=https://$ACCOUNT_ENDPOINT
-NXF_AZURE_STORAGE_ACCOUNT=$STORAGE_ACCOUNT_STD
+AZURE_BATCH_ACCESS_KEY="your-batch-account-access-key"
 AZURE_STORAGE_ACCOUNT_KEY="your-standard-storage-account-key"
+NXF_AZURE_STORAGE_ACCOUNT=$STORAGE_ACCOUNT_STD
 NXF_AZURE_REFERENCE_ACCOUNT=$STORAGE_ACCOUNT_PREM
 NXF_AZURE_REFERENCE_KEY="your-premium-storage-account-key"
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -255,6 +255,7 @@
             ],
             "env": {
                 "LOGGING_DEBUG": "1",
+                // "THROTTLE_BACKEND": "redis",
                 // "CACHE_BACKEND": "azure_blob",
             },
             // "envFile": "${workspaceFolder}/.env.azure",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Documentation of the analysis](https://qcif.github.io/taxodactyl/understanding-the-analysis.html)
 - [Running tests with nf-test](docs/nf-tests.md)
 - [Python scripts](./scripts) (for developers)
+- [Run Taxodactyl on Azure Batch](./docs/azure/)
 
 
 ### Workflow Overview

--- a/conf/azure.config
+++ b/conf/azure.config
@@ -16,7 +16,7 @@ workDir = 'az://workdata/work'
 // Forward rate-limiting config from orchestrator environment to Batch task containers
 env {
     THROTTLE_BACKEND = System.getenv('THROTTLE_BACKEND') ?: 'sqlite'
-    REDIS_HOST       = System.getenv('REDIS_HOST') ?: ''
+    REDIS_HOST       = System.getenv('REDIS_HOST') ?: 'localhost'
     REDIS_PORT       = System.getenv('REDIS_PORT') ?: '6379'
     REDIS_PASSWORD   = System.getenv('REDIS_PASSWORD') ?: ''
 }

--- a/conf/azure.config
+++ b/conf/azure.config
@@ -13,6 +13,14 @@
 // with minimal overhead for small files (metadata, validation results, etc.)
 workDir = 'az://workdata/work'
 
+// Forward rate-limiting config from orchestrator environment to Batch task containers
+env {
+    THROTTLE_BACKEND = System.getenv('THROTTLE_BACKEND') ?: 'sqlite'
+    REDIS_HOST       = System.getenv('REDIS_HOST') ?: ''
+    REDIS_PORT       = System.getenv('REDIS_PORT') ?: '6379'
+    REDIS_PASSWORD   = System.getenv('REDIS_PASSWORD') ?: ''
+}
+
 process {
 
     // All processes run on Azure Batch executor to maximize single-node utilization

--- a/deployment/azure/batch-helpers.sh
+++ b/deployment/azure/batch-helpers.sh
@@ -17,6 +17,12 @@ NC='\033[0m' # No Color
 DEFAULT_POOL_ID="taxodactyl"
 DEFAULT_AUTOSCALE_INTERVAL="PT5M"
 
+# Redis VM
+REDIS_VM_NAME="daff-redis-vm"
+REDIS_VM_HOST="daff-redis.australiaeast.cloudapp.azure.com"
+REDIS_VM_NSG="daff-redis-nsg"
+REDIS_VM_TYPE="Standard_B2ats_v2"
+
 # Autoscale formula: Fast scale-up (5min window), slow scale-down (30min window)
 # Scales to 1 node if ANY tasks in last 5 min OR any tasks in last 30 min
 # This ensures quick response to new tasks while keeping nodes warm
@@ -925,6 +931,124 @@ az_fetch_nf_logs() {
 }
 
 #
+# Redis VM Management
+#
+
+az_redis_vm_status() {
+    _check_env_vars || return 1
+
+    _info "Redis VM: $REDIS_VM_NAME"
+    echo ""
+
+    local power_state
+    power_state=$(az vm get-instance-view \
+        --resource-group "$RESOURCE_GROUP" \
+        --name "$REDIS_VM_NAME" \
+        --query "instanceView.statuses[?starts_with(code, 'PowerState/')].displayStatus" \
+        -o tsv 2>/dev/null)
+
+    if [[ -z "$power_state" ]]; then
+        _error "VM '$REDIS_VM_NAME' not found in resource group '$RESOURCE_GROUP'"
+        return 1
+    fi
+
+    echo -e "  Power state:  $power_state"
+    echo -e "  Hostname:     $REDIS_VM_HOST"
+    echo -e "  Port:         ${REDIS_PORT:-6379}"
+    echo ""
+
+    if [[ "$power_state" == "VM running" ]]; then
+        if nc -z -w3 "$REDIS_VM_HOST" "${REDIS_PORT:-6379}" 2>/dev/null; then
+            _success "Redis is reachable at $REDIS_VM_HOST:${REDIS_PORT:-6379}"
+        else
+            _warning "VM is running but Redis port is not reachable (this may be normal if you are accessing the VM from outside the Azure network)"
+            _info "Check Redis service: az_redis_vm_ssh then 'sudo systemctl status redis-server'"
+        fi
+    fi
+}
+
+az_redis_vm_start() {
+    local skip_confirm=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y) skip_confirm=true; shift ;;
+            *) _error "Unknown argument: $1"; return 1 ;;
+        esac
+    done
+
+    _check_env_vars || return 1
+
+    local power_state
+    power_state=$(az vm get-instance-view \
+        --resource-group "$RESOURCE_GROUP" \
+        --name "$REDIS_VM_NAME" \
+        --query "instanceView.statuses[?starts_with(code, 'PowerState/')].displayStatus" \
+        -o tsv 2>/dev/null)
+
+    if [[ "$power_state" == "VM running" ]]; then
+        _info "Redis VM is already running"
+        return 0
+    fi
+
+    _info "Starting Redis VM '$REDIS_VM_NAME' (current state: ${power_state:-unknown})..."
+
+    if [[ "$skip_confirm" == false ]] && ! _confirm "Start Redis VM?"; then
+        _warning "Start cancelled"
+        return 0
+    fi
+
+    if az vm start \
+        --resource-group "$RESOURCE_GROUP" \
+        --name "$REDIS_VM_NAME"; then
+        _success "Redis VM started"
+        _info "Redis available at $REDIS_VM_HOST:${REDIS_PORT:-6379}"
+    else
+        _error "Failed to start Redis VM"
+        return 1
+    fi
+}
+
+az_redis_vm_stop() {
+    local skip_confirm=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y) skip_confirm=true; shift ;;
+            *) _error "Unknown argument: $1"; return 1 ;;
+        esac
+    done
+
+    _check_env_vars || return 1
+
+    _warning "Stopping Redis VM will make rate-limiting unavailable until restarted"
+    _info "VM: $REDIS_VM_NAME"
+
+    if [[ "$skip_confirm" == false ]] && ! _confirm "Deallocate Redis VM?"; then
+        _warning "Stop cancelled"
+        return 0
+    fi
+
+    _info "Deallocating Redis VM..."
+
+    if az vm deallocate \
+        --resource-group "$RESOURCE_GROUP" \
+        --name "$REDIS_VM_NAME"; then
+        _success "Redis VM deallocated (compute cost stopped)"
+    else
+        _error "Failed to deallocate Redis VM"
+        return 1
+    fi
+}
+
+az_redis_vm_ssh() {
+    _check_env_vars || return 1
+
+    _info "Connecting to Redis VM at $REDIS_VM_HOST..."
+    ssh "azureuser@$REDIS_VM_HOST"
+}
+
+#
 # Utility Functions
 #
 
@@ -964,6 +1088,12 @@ SAS Token Management:
 
 Nextflow Debugging:
   az_fetch_nf_logs [log_file] [output_dir]   Download all command logs from a Nextflow run
+
+Redis VM Management:
+  az_redis_vm_status              Show VM power state and Redis reachability
+  az_redis_vm_start [--yes]       Start a deallocated Redis VM
+  az_redis_vm_stop [--yes]        Deallocate Redis VM (stops compute billing)
+  az_redis_vm_ssh                 Open SSH session to Redis VM
 
 Utility:
   az_help                         Show this help message
@@ -1064,6 +1194,9 @@ else
     echo ""
     echo "  Nextflow Debugging:"
     echo "    az_fetch_nf_logs"
+    echo ""
+    echo "  Redis VM Management:"
+    echo "    az_redis_vm_status, az_redis_vm_start, az_redis_vm_stop, az_redis_vm_ssh"
     echo ""
     echo -e "${GREEN}Run 'az_help' for detailed usage information${NC}"
     echo ""

--- a/deployment/azure/redis-on-demand-plan.md
+++ b/deployment/azure/redis-on-demand-plan.md
@@ -1,0 +1,215 @@
+# Plan: Azure Redis (ACI) for Distributed Rate-Limiting
+
+## Context
+
+The Taxodactyl pipeline's `throttle.py` already supports a Redis backend (`RedisQueueBackend`) for distributed rate-limiting across concurrent workflow instances. When running on Azure Batch, multiple Nextflow workflow runs share the same Batch node and rate-limiting state must be coordinated between containerised tasks to avoid hitting API limits (GBIF, NCBI Entrez, BOLD). The SQLite backend is insufficient because each containerised Batch task gets its own filesystem.
+
+Redis needs to be on-demand (not running 24/7), shared across all Batch task containers, and cost-effective (~$0 when idle).
+
+## Architecture: VNet-private ACI with TTL-tag cleanup
+
+Run `redis:7-alpine` as an ACI container group (`daff-redis`) on a private subnet within a new VNet. Lifecycle is managed via an `expiresAt` tag (refreshed on each workflow start) and a cron job on the always-on web server that deletes the ACI when the tag lapses.
+
+**Why this approach:**
+- **Private networking**: no public Redis exposure; no password required (though one will still be set)
+- **TTL-via-tag**: no `trap`, no `redis-cli` dependency on the orchestrator, no process coordination — the workflow stamps a tag and walks away; crash-tolerant by design
+- **"Last write wins"**: concurrent workflows each refresh `expiresAt`; the ACI outlives all of them without coordination
+- **Cron cleanup on always-on web server**: reliable runner, no extra Azure services (Automation Account, Logic App, etc.)
+
+---
+
+## Infrastructure Changes (one-time setup)
+
+### 1. VNet and subnets
+
+Create a VNet and two subnets in resource group `daff-biosecurity`, region `australiaeast`:
+
+```bash
+az network vnet create \
+  --resource-group daff-biosecurity \
+  --name daff-vnet \
+  --address-prefixes 10.0.0.0/16
+
+az network vnet subnet create \
+  --resource-group daff-biosecurity \
+  --vnet-name daff-vnet \
+  --name aci-subnet \
+  --address-prefixes 10.0.1.0/24 \
+  --delegations Microsoft.ContainerInstance/containerGroups
+
+az network vnet subnet create \
+  --resource-group daff-biosecurity \
+  --vnet-name daff-vnet \
+  --name batch-subnet \
+  --address-prefixes 10.0.2.0/24
+```
+
+Optional NSG rule: allow Batch → ACI on TCP 6379.
+
+### 2. Batch pool recreation
+
+The existing `taxodactyl` pool has no VNet. It must be deleted and recreated with `--subnet-id` pointing to `batch-subnet`. This is a one-time disruption — document the current pool config before deleting.
+
+`pool-setup.json.template` gains a `networkConfiguration.subnetId` field.
+
+### 3. Private DNS zone (optional but recommended)
+
+A Private DNS zone (`redis.internal`) resolves `daff-redis.redis.internal` to the ACI's private IP, avoiding the need to query the IP dynamically on each run:
+
+```bash
+az network private-dns zone create \
+  --resource-group daff-biosecurity \
+  --name redis.internal
+
+az network private-dns link vnet create \
+  --resource-group daff-biosecurity \
+  --zone-name redis.internal \
+  --name daff-vnet-link \
+  --virtual-network daff-vnet \
+  --registration-enabled false
+```
+
+An A record pointing `daff-redis` → ACI private IP is created/updated by `az_redis_start`.
+
+---
+
+## Files to Modify
+
+### 1. `deployment/azure/batch-helpers.sh`
+
+Add a new **Redis Management** section (before `az_help`) with constants and functions.
+
+**Constants** (top of file alongside existing defaults):
+```bash
+REDIS_CONTAINER_GROUP="daff-redis"
+REDIS_VNET="daff-vnet"
+REDIS_SUBNET="aci-subnet"
+REDIS_PORT="6379"
+REDIS_CPU="0.5"
+REDIS_MEMORY_GB="0.5"
+REDIS_DEFAULT_TTL_HOURS="6"   # expiresAt = now + 6h; tune to expected max workflow runtime
+```
+
+**Functions:**
+
+`az_redis_start [--ttl-hours N] [--yes]`
+- Checks `RESOURCE_GROUP` env var is set
+- Computes `expiresAt = $(date -u -d "+N hours" +%s)` (Unix timestamp)
+- Queries current container group state via `az container show`
+- If **Running**: updates `tags.expiresAt` only (`az container update --set tags.expiresAt=...`) — no restart
+- If **not found**: creates ACI in `aci-subnet` with `--ip-address Private`, `--tags expiresAt=... role=ephemeral-redis`, and Redis server command with password, maxmemory, and persistence disabled
+- Waits for `Running` state (polls up to 60s)
+- If Private DNS is configured: upserts the A record with the ACI's private IP
+- Prints private IP and connection info
+
+`az_redis_stop [--yes]`
+- Confirms unless `--yes`
+- Runs `az container stop` — deallocates compute, preserves container definition for fast restart
+
+`az_redis_delete [--yes]`
+- Confirms with strong warning
+- Runs `az container delete`
+
+`az_redis_status`
+- Shows container state, private IP, `expiresAt` tag (formatted as human-readable datetime), time remaining
+
+`az_redis_ensure_running [--ttl-hours N]`
+- Non-interactive `az_redis_start --yes` for use in scripts
+
+`az_redis_cleanup`
+- Lists all ACIs tagged `role=ephemeral-redis` in the resource group
+- Deletes any where `expiresAt < now - grace_period (5 min)`
+- **This is the function called by the cron job on the web server**
+
+`az_redis_ping`
+- Uses `redis-cli` (if available) or `nc` to test connectivity
+- Note: only reachable from within the VNet (Batch node) or via VPN; documented accordingly
+
+Update the **sourced startup banner** and `az_help` examples.
+
+### 2. `deployment/azure/run-taxodactyl.sh`
+
+After loading `.env.azure`, when `THROTTLE_BACKEND=redis`:
+
+```bash
+if [[ "${THROTTLE_BACKEND:-}" == "redis" ]]; then
+    source "$(dirname "$0")/batch-helpers.sh" 2>/dev/null
+    az_redis_ensure_running --ttl-hours "${REDIS_TTL_HOURS:-6}"
+    # Retrieve private IP unless already set (e.g. via Private DNS)
+    if [[ -z "${REDIS_HOST:-}" ]]; then
+        REDIS_HOST=$(az container show \
+            --resource-group "$RESOURCE_GROUP" \
+            --name "$REDIS_CONTAINER_GROUP" \
+            --query "ipAddress.ip" -o tsv)
+        export REDIS_HOST
+    fi
+fi
+```
+
+If Private DNS is configured, `REDIS_HOST=daff-redis.redis.internal` can be set in `.env.azure` and the dynamic lookup is skipped.
+
+Pass `REDIS_HOST` and `REDIS_PORT` into the Nextflow run via env so Batch task containers inherit them.
+
+### 3. `deployment/azure/pool-setup.json.template`
+
+Add `networkConfiguration` block:
+```json
+"networkConfiguration": {
+    "subnetId": "/subscriptions/.../resourceGroups/daff-biosecurity/providers/Microsoft.Network/virtualNetworks/daff-vnet/subnets/batch-subnet"
+}
+```
+
+### 4. `.env.azure.sample`
+
+Add:
+```bash
+# Redis (distributed rate-limiting via ACI on private VNet)
+THROTTLE_BACKEND=redis
+REDIS_PASSWORD="your-strong-redis-password"
+REDIS_PORT=6379
+REDIS_TTL_HOURS=6
+# REDIS_HOST is set dynamically by run-taxodactyl.sh, or hardcode if using Private DNS:
+# REDIS_HOST=daff-redis.redis.internal
+```
+
+---
+
+## Files to Create
+
+### 5. `docs/azure/07-redis.md`
+
+Document:
+- Architecture (ACI on private VNet, TTL-tag lifecycle)
+- One-time setup: VNet, subnets, Batch pool recreation, optional Private DNS
+- Workflow integration: what `run-taxodactyl.sh` does automatically
+- Cleanup cron job setup on the web server (command, recommended interval: 10 min)
+- Tuning `REDIS_TTL_HOURS` for expected workflow runtimes
+- Troubleshooting: `az_redis_status`, ACI logs, `az_redis_ping` (VNet-only)
+
+### 6. Update `docs/azure/README.md`
+
+Add `7. **[Redis](07-redis.md)**` to the Documentation Index and add Redis helper functions to the helper function listing.
+
+---
+
+## Cron Job (web server)
+
+Add to crontab on the always-on web server:
+
+```cron
+*/10 * * * * cd /path/to/wf2-nextflow && source deployment/azure/batch-helpers.sh && az_redis_cleanup
+```
+
+Requires: `az` CLI authenticated on the web server (service principal or managed identity), `.env.azure` readable.
+
+---
+
+## Verification
+
+1. `az network vnet list` — confirm `daff-vnet` with both subnets
+2. `az_redis_start` — creates ACI, waits for Running, prints private IP
+3. `az_redis_status` — shows Running, `expiresAt` ~6h from now
+4. Submit a Nextflow run via `run-taxodactyl.sh` — confirm `REDIS_HOST` resolved, Batch tasks connect to Redis
+5. `az_redis_cleanup` with an artificially past `expiresAt` tag — confirm ACI is deleted
+6. Run cron job on web server — confirm it executes cleanly
+7. `az_redis_start` again — confirm recreation completes in ~30–45s

--- a/deployment/azure/redis-vm-plan.md
+++ b/deployment/azure/redis-vm-plan.md
@@ -1,0 +1,164 @@
+# Plan: Always-On Redis VM for Distributed Rate-Limiting
+
+## Context
+
+Alternative to the ephemeral ACI approach. A small always-on VM running Redis is simpler to set up and operate — no lifecycle management, no cron cleanup job, no TTL tags. The tradeoff is a fixed cost of ~$8.69/month (PAYG) regardless of usage.
+
+## Architecture: Standard_B2ats_v2 VM
+
+> Standard_B2ats_v2 was the best VM I could find that is cheap, available in the australiaeast region, and has quota available
+
+A `Standard_B2ats_v2` VM (2 vCPU, 1GB RAM) running Redis as a systemd service. Redis is small enough that 1GB RAM is comfortable for rate-limiting workloads (token bucket counters only, no large data sets).
+
+**Cost:** ~US$8.69/month
+
+**Tradeoffs vs ephemeral ACI:**
+- Simpler: no lifecycle management, no cron job, static `REDIS_HOST` in `.env.azure`
+- More expensive when workflows run infrequently (ACI costs $0 when stopped)
+- More appropriate when workflows run daily or near-daily
+
+---
+
+## Infrastructure Changes (one-time setup)
+
+### 1. Create the VM
+
+```bash
+az vm create \
+  --resource-group daff-biosecurity \
+  --name daff-redis-vm \
+  --image Ubuntu2204 \
+  --size Standard_B2ats_v2 \
+  --admin-username azureuser \
+  --generate-ssh-keys \
+  --public-ip-sku Standard \
+  --public-ip-address-dns-name daff-redis \
+  --nsg daff-redis-nsg
+```
+
+This gives a stable DNS hostname: `daff-redis.australiaeast.cloudapp.azure.com`
+
+### 2. NSG rule: restrict Redis port
+
+Allow port 6379 inbound only from Azure Batch node IPs (or Azure datacenter range if dynamic):
+
+```bash
+az network nsg rule create \
+  --resource-group daff-biosecurity \
+  --nsg-name daff-redis-nsg \
+  --name allow-redis \
+  --priority 100 \
+  --protocol Tcp \
+  --destination-port-ranges 6379 \
+  --source-address-prefixes AzureCloud \
+  --access Allow
+```
+
+Alternatively, if the Batch pool is placed on a VNet (see `redis-plan.md`), omit the public IP entirely and use a private IP on `batch-subnet`.
+
+### 3. Install and configure Redis
+
+SSH into the VM and run:
+
+```bash
+sudo apt update && sudo apt install -y redis-server
+
+# Set password and bind address
+sudo sed -i "s/^# requirepass.*/requirepass YOUR_PASSWORD/" /etc/redis/redis.conf
+sudo sed -i "s/^bind 127.0.0.1.*/bind 0.0.0.0/" /etc/redis/redis.conf
+sudo sed -i "s/^# maxmemory .*/maxmemory 256mb/" /etc/redis/redis.conf
+sudo sed -i "s/^# maxmemory-policy.*/maxmemory-policy allkeys-lru/" /etc/redis/redis.conf
+
+# Disable persistence (rate-limit counters don't need to survive reboots)
+sudo sed -i "s/^save 900/# save 900/" /etc/redis/redis.conf
+sudo sed -i "s/^save 300/# save 300/" /etc/redis/redis.conf
+sudo sed -i "s/^save 60/# save 60/" /etc/redis/redis.conf
+
+sudo systemctl restart redis-server
+sudo systemctl enable redis-server
+```
+
+This configuration can be templated as `deployment/azure/redis-vm-setup.sh` to make it reproducible.
+
+---
+
+## Files to Modify
+
+### 1. `deployment/azure/batch-helpers.sh`
+
+Add a **Redis VM Management** section with lightweight helpers (the VM is always-on, so these are mostly for maintenance):
+
+**Constants:**
+```bash
+REDIS_VM_NAME="daff-redis-vm"
+REDIS_VM_HOST="daff-redis.australiaeast.cloudapp.azure.com"
+REDIS_VM_NSG=daff-redis-nsg
+REDIS_VM_TYPE=Standard_B2ats_v2
+```
+
+**Functions:**
+
+`az_redis_vm_status`
+- Runs `az vm show` to display power state, public IP, and DNS hostname
+- Shows whether Redis process is reachable via `nc`
+
+`az_redis_vm_start [--yes]`
+- Starts a deallocated VM: `az vm start`
+- For use after manual `az_redis_vm_stop` (maintenance)
+
+`az_redis_vm_stop [--yes]`
+- Deallocates the VM: `az vm deallocate`
+- Frees compute cost while preserving OS disk
+- Warning: Redis will be unavailable until restarted
+
+`az_redis_vm_ssh`
+- Opens an SSH session to the VM for maintenance
+
+### 2. `.env.azure.sample`
+
+Add:
+```bash
+# Redis VM (always-on, distributed rate-limiting)
+THROTTLE_BACKEND=redis
+REDIS_HOST=daff-redis.australiaeast.cloudapp.azure.com
+REDIS_PORT=6379
+REDIS_PASSWORD="your-strong-redis-password"
+```
+
+### 3. `deployment/azure/run-taxodactyl.sh`
+
+No changes needed for lifecycle — `REDIS_HOST` is static. Optionally add a pre-flight check:
+
+```bash
+if [[ "${THROTTLE_BACKEND:-}" == "redis" ]] && [[ -n "${REDIS_HOST:-}" ]]; then
+    if ! nc -z -w3 "$REDIS_HOST" "${REDIS_PORT:-6379}" 2>/dev/null; then
+        echo -e "${YELLOW}WARNING: Redis at $REDIS_HOST:$REDIS_PORT is unreachable${NC}"
+    fi
+fi
+```
+
+---
+
+## Files to Create
+
+### 4. `deployment/azure/redis-vm-setup.sh`
+
+Idempotent setup script to run on the VM after creation. Installs Redis, applies configuration, enables systemd service. Can be re-run safely for config updates.
+
+### 5. `docs/azure/07-redis.md`
+
+- VM creation and Redis setup steps
+- NSG configuration
+- Connection from Batch nodes
+- Maintenance: SSH access, config changes, `az_redis_vm_stop`/`start` for planned downtime
+- Monitoring: `az_redis_vm_status`
+
+---
+
+## Verification
+
+1. `az_redis_vm_status` — shows Running, prints hostname
+2. `redis-cli -h daff-redis.australiaeast.cloudapp.azure.com -p 6379 -a $REDIS_PASSWORD ping` → `PONG`
+3. Set `.env.azure` with `THROTTLE_BACKEND=redis`, `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`
+4. Run `deployment/azure/run-taxodactyl.sh` — Batch tasks connect to Redis successfully
+5. `az_redis_vm_stop` then `az_redis_vm_start` — confirm Redis recovers correctly

--- a/deployment/azure/redis-vm-setup.sh
+++ b/deployment/azure/redis-vm-setup.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Redis VM Setup Script
+#
+# Run this script on the daff-redis-vm after creation to install and configure
+# Redis for distributed rate-limiting. Safe to re-run for config updates.
+#
+# Usage (from your local machine):
+#   ssh azureuser@daff-redis.australiaeast.cloudapp.azure.com \
+#       'bash -s' < deployment/azure/redis-vm-setup.sh
+#
+# Or after SSH-ing in:
+#   bash redis-vm-setup.sh
+#
+
+set -euo pipefail
+
+REDIS_CONF="/etc/redis/redis.conf"
+MAXMEMORY="256mb"
+
+if [[ -z "${REDIS_PASSWORD:-}" ]]; then
+    echo "ERROR: REDIS_PASSWORD environment variable is not set"
+    echo "Export it before running: export REDIS_PASSWORD=your-password"
+    exit 1
+fi
+
+echo "=== Installing Redis ==="
+sudo apt-get update -qq
+sudo apt-get install -y redis-server
+
+echo ""
+echo "=== Configuring Redis ==="
+
+# Password
+if sudo grep -q "^requirepass " "$REDIS_CONF"; then
+    sudo sed -i "s|^requirepass .*|requirepass $REDIS_PASSWORD|" "$REDIS_CONF"
+else
+    sudo sed -i "s|^# requirepass .*|requirepass $REDIS_PASSWORD|" "$REDIS_CONF"
+fi
+
+# Bind to all interfaces (NSG restricts access at the network level)
+sudo sed -i "s|^bind 127\.0\.0\.1.*|bind 0.0.0.0|" "$REDIS_CONF"
+
+# Memory limit
+if sudo grep -q "^maxmemory " "$REDIS_CONF"; then
+    sudo sed -i "s|^maxmemory .*|maxmemory $MAXMEMORY|" "$REDIS_CONF"
+else
+    sudo sed -i "s|^# maxmemory .*|maxmemory $MAXMEMORY|" "$REDIS_CONF"
+fi
+
+# Eviction policy
+if sudo grep -q "^maxmemory-policy " "$REDIS_CONF"; then
+    sudo sed -i "s|^maxmemory-policy .*|maxmemory-policy allkeys-lru|" "$REDIS_CONF"
+else
+    sudo sed -i "s|^# maxmemory-policy .*|maxmemory-policy allkeys-lru|" "$REDIS_CONF"
+fi
+
+# Disable persistence (rate-limit counters don't need to survive reboots)
+sudo sed -i "s|^save 900|# save 900|" "$REDIS_CONF"
+sudo sed -i "s|^save 300|# save 300|" "$REDIS_CONF"
+sudo sed -i "s|^save 60|# save 60|" "$REDIS_CONF"
+
+echo ""
+echo "=== Configuring firewall ==="
+if sudo ufw status | grep -q "Status: active"; then
+    sudo ufw allow 6379/tcp comment "Redis"
+    echo "ufw rule added for port 6379"
+else
+    echo "ufw is inactive - relying on Azure NSG for network access control"
+fi
+
+echo ""
+echo "=== Starting Redis ==="
+sudo systemctl restart redis-server
+sudo systemctl enable redis-server
+
+echo ""
+echo "=== Verifying ==="
+sleep 1
+if redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping | grep -q PONG; then
+    echo "Redis is running and responding"
+    echo ""
+    echo "Connection details:"
+    echo "  Host: $(curl -s ifconfig.me 2>/dev/null || hostname -I | awk '{print $1}')"
+    echo "  Port: 6379"
+else
+    echo "ERROR: Redis did not respond to PING"
+    sudo systemctl status redis-server
+    exit 1
+fi

--- a/deployment/azure/run-taxodactyl.sh
+++ b/deployment/azure/run-taxodactyl.sh
@@ -93,6 +93,18 @@ if [[ -z "${AZURE_BATCH_ACCESS_KEY:-}" ]]; then
     exit 1
 fi
 
+# Check Redis reachability if configured
+if [[ "${THROTTLE_BACKEND:-}" == "redis" ]] && [[ -n "${REDIS_HOST:-}" ]]; then
+    echo -e "${YELLOW}Checking Redis connectivity at $REDIS_HOST:${REDIS_PORT:-6379}...${NC}"
+    if nc -z -w5 "$REDIS_HOST" "${REDIS_PORT:-6379}" 2>/dev/null; then
+        echo -e "${GREEN}Redis is reachable${NC}"
+    else
+        echo -e "${RED}ERROR: Redis at $REDIS_HOST:${REDIS_PORT:-6379} is not reachable${NC}"
+        echo "Check that the Redis VM is running: az_redis_vm_status"
+        exit 1
+    fi
+fi
+
 # Show configuration
 echo ""
 echo -e "${YELLOW}=== Taxodactyl Azure Batch Configuration ===${NC}"

--- a/deployment/azure/run-taxodactyl.sh
+++ b/deployment/azure/run-taxodactyl.sh
@@ -95,14 +95,7 @@ fi
 
 # Check Redis reachability if configured
 if [[ "${THROTTLE_BACKEND:-}" == "redis" ]] && [[ -n "${REDIS_HOST:-}" ]]; then
-    echo -e "${YELLOW}Checking Redis connectivity at $REDIS_HOST:${REDIS_PORT:-6379}...${NC}"
-    if nc -z -w5 "$REDIS_HOST" "${REDIS_PORT:-6379}" 2>/dev/null; then
-        echo -e "${GREEN}Redis is reachable${NC}"
-    else
-        echo -e "${RED}ERROR: Redis at $REDIS_HOST:${REDIS_PORT:-6379} is not reachable${NC}"
-        echo "Check that the Redis VM is running: az_redis_vm_status"
-        exit 1
-    fi
+    echo -e "${YELLOW}Redis backend enabled at $REDIS_HOST:${REDIS_PORT:-6379} (status unknown)${NC}"
 fi
 
 # Show configuration

--- a/docs/azure/07-redis.md
+++ b/docs/azure/07-redis.md
@@ -1,0 +1,155 @@
+# Redis VM for Distributed Rate-Limiting
+
+Taxodactyl enforces API rate limits (GBIF, NCBI Entrez, BOLD) using a token bucket algorithm in `scripts/src/utils/throttle.py`. When multiple workflow instances run concurrently on the same Azure Batch node, they need to share rate-limiting state — a single Redis instance coordinates this across all containers.
+
+## Deployment options
+
+Two deployment strategies have been evaluated:
+
+| | Always-on VM (current) | On-demand ACI |
+|---|---|---|
+| **Cost** | ~$8.69/month fixed | ~$0.03/hr running, $0 idle |
+| **Complexity** | Low — static hostname, no lifecycle management | Higher — VNet, cron cleanup, dynamic IP |
+| **Best for** | Daily or near-daily workflow use | Infrequent use |
+
+The always-on VM approach is currently deployed and documented below. The on-demand ACI approach (ephemeral Redis via Azure Container Instances on a private VNet, with TTL-tag lifecycle management) is documented in [deployment/azure/redis-on-demand-plan.md](../../deployment/azure/redis-on-demand-plan.md) for reference if a lower-cost alternative is needed in future.
+
+## Architecture
+
+A small always-on VM (`Standard_B2ats_v2`, 2 vCPU / 1 GB RAM) runs Redis as a systemd service. Batch task containers connect to it over its public IP, which is restricted by an NSG to accept connections only from within Azure's datacenter range.
+
+**Cost:** ~US$8.69/month
+
+**Why not Azure Cache for Redis?** The Basic tier starts at ~$16/month and is always-on. The VM approach is cheaper and gives full control over the Redis configuration.
+
+## One-Time Setup
+
+These steps are already complete for the `daff-biosecurity` environment. They are documented here for reference and disaster recovery.
+
+### 1. Create the VM
+
+```bash
+az vm create \
+  --resource-group daff-biosecurity \
+  --name daff-redis-vm \
+  --image Ubuntu2204 \
+  --size Standard_B2ats_v2 \
+  --admin-username azureuser \
+  --generate-ssh-keys \
+  --public-ip-sku Standard \
+  --public-ip-address-dns-name daff-redis \
+  --nsg daff-redis-nsg
+```
+
+Stable DNS hostname: `daff-redis.australiaeast.cloudapp.azure.com`
+
+### 2. Restrict the Redis port
+
+```bash
+az network nsg rule create \
+  --resource-group daff-biosecurity \
+  --nsg-name daff-redis-nsg \
+  --name allow-redis \
+  --priority 100 \
+  --protocol Tcp \
+  --destination-port-ranges 6379 \
+  --source-address-prefixes AzureCloud \
+  --access Allow
+```
+
+This allows port 6379 from Azure's datacenter IP ranges only. Connections from outside Azure are blocked.
+
+### 3. Install and configure Redis
+
+Set `REDIS_PASSWORD` in your shell, then pipe the setup script to the VM:
+
+```bash
+export REDIS_PASSWORD="your-password"
+ssh azureuser@daff-redis.australiaeast.cloudapp.azure.com \
+    "REDIS_PASSWORD=$REDIS_PASSWORD bash -s" < deployment/azure/redis-vm-setup.sh
+```
+
+The setup script (`deployment/azure/redis-vm-setup.sh`) is idempotent and can be re-run if configuration needs to be updated.
+
+## Configuration
+
+Add the following to `.env.azure` (see `.env.azure.sample`):
+
+```bash
+THROTTLE_BACKEND=redis
+REDIS_HOST=daff-redis.australiaeast.cloudapp.azure.com
+REDIS_PORT=6379
+REDIS_PASSWORD="your-password"
+```
+
+When `THROTTLE_BACKEND=redis` is set, `run-taxodactyl.sh` will verify Redis is reachable before submitting the workflow. If it is not reachable, the script will exit with an error rather than falling back to SQLite.
+
+## Helper Functions
+
+```bash
+source deployment/azure/batch-helpers.sh
+
+# Check VM state and Redis reachability
+az_redis_vm_status
+
+# Start a stopped VM (e.g. after planned maintenance)
+az_redis_vm_start
+
+# Deallocate VM to stop billing (Redis will be unavailable)
+az_redis_vm_stop
+
+# SSH into the VM for maintenance
+az_redis_vm_ssh
+```
+
+## Maintenance
+
+### Updating the Redis password
+
+1. SSH into the VM: `az_redis_vm_ssh`
+2. Edit `/etc/redis/redis.conf` and update the `requirepass` line
+3. `sudo systemctl restart redis-server`
+4. Update `REDIS_PASSWORD` in `.env.azure` on all machines that run workflows
+
+Alternatively, re-run the setup script with the new password:
+
+```bash
+export REDIS_PASSWORD="new-password"
+ssh azureuser@daff-redis.australiaeast.cloudapp.azure.com \
+    "REDIS_PASSWORD=$REDIS_PASSWORD bash -s" < deployment/azure/redis-vm-setup.sh
+```
+
+### Planned downtime
+
+```bash
+az_redis_vm_stop    # deallocates VM, stops billing
+# ... maintenance ...
+az_redis_vm_start   # restarts VM, Redis auto-starts via systemd
+```
+
+### Checking Redis logs
+
+```bash
+az_redis_vm_ssh
+sudo journalctl -u redis-server -f
+```
+
+## Troubleshooting
+
+**`run-taxodactyl.sh` reports Redis unreachable**
+
+1. `az_redis_vm_status` — check VM power state
+2. If deallocated: `az_redis_vm_start`
+3. If running but not reachable: `az_redis_vm_ssh` then `sudo systemctl status redis-server`
+
+**Rate-limiting not coordinating between instances**
+
+Verify `THROTTLE_BACKEND=redis` is set in `.env.azure` and the containers are receiving `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` as environment variables. Check `scripts/src/utils/throttle.py` for which env vars are read.
+
+**Manually testing connectivity from a Batch node**
+
+SSH into the node and run:
+
+```bash
+redis-cli -h daff-redis.australiaeast.cloudapp.azure.com -p 6379 -a "$REDIS_PASSWORD" --no-auth-warning ping
+```

--- a/docs/azure/README.md
+++ b/docs/azure/README.md
@@ -2,6 +2,10 @@
 
 This directory contains comprehensive documentation for running Taxodactyl workflows on Azure Batch.
 
+> [!NOTE]
+> Setting up an Azure environment to run Taxodactyl is not trivial, but we include helper scripts in ./deployment/azure to make this easier.
+> At minimum, you will need a Batch account and pool configured, and a storage account with multiple containers of reference and other data. For production deployment we also use a Redis server for coordinating concurrent rate-limiting across nodes/tasks, and a key vault for storing user API credentials.
+
 ## Quick start - running the workflow on Azure
 
 This assumes that you have an Azure Batch pool set up and configured according

--- a/docs/azure/README.md
+++ b/docs/azure/README.md
@@ -25,6 +25,7 @@ This results in a nice balance between cost and performance - it costs nothing u
 4. **[Start Tasks](04-start-tasks.md)** - Configuring start tasks for node initialization and reference data staging
 5. **[Troubleshooting](05-troubleshooting.md)** - Common issues and debugging techniques
 6. **[Maintenance](06-maintenance.md)** - Recurring maintenance tasks (SAS rotation, cache cleanup, key rotation)
+7. **[Redis](07-redis.md)** - Always-on Redis VM for distributed rate-limiting across concurrent workflow instances
 
 ## Azure CLI
 
@@ -74,6 +75,12 @@ az_jobs_list                    # List recent jobs
 
 **SAS Token Management:**
 - `az_sas_generate <blob> [account] [container] [days]` - Generate SAS tokens
+
+**Redis VM Management:**
+- `az_redis_vm_status` - Show VM power state and Redis reachability
+- `az_redis_vm_start [--yes]` - Start a deallocated Redis VM
+- `az_redis_vm_stop [--yes]` - Deallocate Redis VM (stops compute billing)
+- `az_redis_vm_ssh` - Open SSH session to Redis VM
 
 All destructive operations (create, delete, resize, update, upload) require confirmation unless `--yes` flag is provided for scripting.
 

--- a/scripts/config/default.yml
+++ b/scripts/config/default.yml
@@ -49,6 +49,7 @@ sqlite_file: db.sqlite
 entrez_cache_dirname: entrez_cache
 cache_timeout_hours: 168
 cache_disabled: false
+throttle_backend: sqlite
 max_api_retries: 3
 errors_dir: errors
 temp_dir_name: biosecurity

--- a/scripts/requirements.in
+++ b/scripts/requirements.in
@@ -13,3 +13,5 @@ debugpy
 azure-core
 azure-identity
 azure-storage-blob
+redis
+redis-rate-limiters

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -77,6 +77,8 @@ pyparsing==3.2.3
 pyppeteer==2.0.0
 pyproj==3.7.1
 pyquery==2.0.1
+redis==5.3.0
+redis-rate-limiters==0.5.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 pytz==2025.2

--- a/scripts/src/entrez/genbank.py
+++ b/scripts/src/entrez/genbank.py
@@ -19,10 +19,10 @@ DEBUG_REQUESTS = True
 EFETCH_BATCH_SIZE = 10
 AUTOMATED_ANNOTATION_TAG = '##Genome-Annotation-Data-START##'
 
-Entrez.email = config.USER_EMAIL
-if config.NCBI_API_KEY:
-    logger.info(f"Using NCBI API key: {config.NCBI_API_KEY[:5]}*********")
-    Entrez.api_key = config.NCBI_API_KEY
+Entrez.email = config.user_email
+if config.ncbi_api_key:
+    logger.info(f"Using NCBI API key: {config.ncbi_api_key[:5]}*********")
+    Entrez.api_key = config.ncbi_api_key
 
 
 class GbRecordSource:

--- a/scripts/src/entrez/genbank.py
+++ b/scripts/src/entrez/genbank.py
@@ -255,7 +255,6 @@ def fetch_gb_records(
     if locus:
         query += f' AND ({locus.genbank_query_str})'
     max_results = 1 if count else 100
-    logger.debug(f"Submitting Entrez query: <<{query}>>")
     results = fetch_entrez(
         endpoint=Entrez.esearch,
         term=query,

--- a/scripts/src/taxonomy/extract.py
+++ b/scripts/src/taxonomy/extract.py
@@ -2,6 +2,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import threading
 
 from src.utils import errors
 from src.utils.config import Config
@@ -9,6 +10,7 @@ from src.utils.config import Config
 logger = logging.getLogger(__name__)
 config = Config()
 
+_taxonkit_semaphore = threading.Semaphore(1)
 
 TAXONOMIC_RANKS = [
     "domain",
@@ -75,7 +77,7 @@ def taxonomies(taxids: list[str]) -> dict[str, dict[str, str]]:
         temp_file_name = temp_file.name
 
     try:
-        result = subprocess.run(
+        result = _run_taxonkit(
             [
                 'taxonkit',
                 'lineage',
@@ -83,9 +85,6 @@ def taxonomies(taxids: list[str]) -> dict[str, dict[str, str]]:
                 '-c', temp_file_name,
                 '--data-dir', config.taxdb_dir,
             ],
-            capture_output=True,
-            check=True,
-            text=True,
         )
     except subprocess.CalledProcessError as exc:
         logger.error(
@@ -142,16 +141,13 @@ def taxids(
         temp_file.flush()
         temp_file_name = temp_file.name
     try:
-        res = subprocess.run(
+        res = _run_taxonkit(
             [
                 'taxonkit',
                 'name2taxid',
-                temp_file.name,
+                temp_file_name,
                 '--data-dir', config.taxdb_dir,
             ],
-            capture_output=True,
-            text=True,
-            check=True,
         )
     except subprocess.CalledProcessError as exc:
         logger.error(
@@ -208,6 +204,18 @@ def taxids(
         )
 
     return taxid_data
+
+
+def _run_taxonkit(args, kwargs={}) -> subprocess.CompletedProcess:
+    """Call taxonkit using a semaphore to ensure only one concurrent call."""
+    kwargs = {
+        'capture_output': True,
+        'text': True,
+        'check': True,
+        **kwargs,
+    }
+    with _taxonkit_semaphore:
+        return subprocess.run(args, **kwargs)
 
 
 def _parse_taxonkit_lineage(output: str) -> list[TaxonkitLineageResult]:
@@ -270,18 +278,16 @@ def _parse_and_filter_taxonkit_name2taxid(
         return filtered_name_results + no_taxid_results
 
     try:
-        process = subprocess.run(
+        process = _run_taxonkit(
             [
                 'taxonkit',
                 'lineage',
                 '-R',
-                '--data-dir',
-                config.taxdb_dir,
+                '--data-dir', config.taxdb_dir,
             ],
-            input="\n".join(taxid_to_results.keys()),
-            capture_output=True,
-            text=True,
-            check=True,
+            {
+                'input': "\n".join(taxid_to_results.keys()),
+            },
         )
         matching_taxids: set[str] = set()
         for lineage_result in _parse_taxonkit_lineage(process.stdout):

--- a/scripts/src/utils/config/config.py
+++ b/scripts/src/utils/config/config.py
@@ -46,10 +46,11 @@ VARS_FROM_ENV = (
     "REDIS_HOST",
     "REDIS_PORT",
     "REDIS_PASSWORD",
+    "THROTTLE_BACKEND",
 )
-REDIS_DEFAULTS = {
+ENV_VAR_DEFAULTS = {
     "REDIS_HOST": "localhost",
-    "REDIS_PORT": "6380",
+    "REDIS_PORT": "6379",
     "REDIS_PASSWORD": None,
 }
 TEMP_FILES = (
@@ -170,6 +171,7 @@ class Config:
         self._load_cascading_config()
         self.output_dir = Path(os.getenv("OUTPUT_DIR", 'output'))
         self.query_dir = None
+        print(f"Env var THROTTLE_BACKEND={os.getenv('THROTTLE_BACKEND')}")  # ! NOCOMMIT
 
     def _get_config_paths(self) -> list[Path]:
         """Parse command line to get config file paths.
@@ -246,7 +248,7 @@ class Config:
             setattr(self, field_name, field_value)
 
         for var in VARS_FROM_ENV:
-            value = os.getenv(var, REDIS_DEFAULTS.get(var))
+            value = os.getenv(var, ENV_VAR_DEFAULTS.get(var))
             setattr(self, var, value)
 
         self._apply_env_overrides()

--- a/scripts/src/utils/config/config.py
+++ b/scripts/src/utils/config/config.py
@@ -40,19 +40,6 @@ DEFAULT_CONFIG_PATH = ROOT_DIR / 'scripts/config/default.yml'
 METADATA_IGNORE_FIELDS = (
     'sequence',
 )
-VARS_FROM_ENV = (
-    "USER_EMAIL",
-    "NCBI_API_KEY",
-    "REDIS_HOST",
-    "REDIS_PORT",
-    "REDIS_PASSWORD",
-    "THROTTLE_BACKEND",
-)
-ENV_VAR_DEFAULTS = {
-    "REDIS_HOST": "localhost",
-    "REDIS_PORT": "6379",
-    "REDIS_PASSWORD": None,
-}
 TEMP_FILES = (
     'entrez_cache_dirname',
 )
@@ -246,10 +233,6 @@ class Config:
             field_value = getattr(self._config, field_name)
             setattr(self, field_name, field_value)
 
-        for var in VARS_FROM_ENV:
-            value = os.getenv(var, ENV_VAR_DEFAULTS.get(var))
-            setattr(self, var, value)
-
         self._apply_env_overrides()
 
     def _apply_env_overrides(self):
@@ -398,9 +381,10 @@ class Config:
     def throttle_sqlite_global_path(self):
         return self.tempdir / ('throttle_' + self.sqlite_file)
 
-    def REDIS_SSL(self):
+    @property
+    def redis_ssl(self):
         """Azure Cache for Redis uses SSL on port 6380."""
-        return int(self.REDIS_PORT) == 6380
+        return self.redis_port == 6380
 
     @property
     def cache_sqlite_path(self):

--- a/scripts/src/utils/config/config.py
+++ b/scripts/src/utils/config/config.py
@@ -369,7 +369,7 @@ class Config:
 
     @property
     def user_tempdir(self):
-        user_dir = self.tempdir / (self.USER_EMAIL or 'ANONYMOUS')
+        user_dir = self.tempdir / (self.user_email or 'ANONYMOUS')
         user_dir.mkdir(exist_ok=True, parents=True)
         return user_dir
 

--- a/scripts/src/utils/config/config.py
+++ b/scripts/src/utils/config/config.py
@@ -171,7 +171,6 @@ class Config:
         self._load_cascading_config()
         self.output_dir = Path(os.getenv("OUTPUT_DIR", 'output'))
         self.query_dir = None
-        print(f"Env var THROTTLE_BACKEND={os.getenv('THROTTLE_BACKEND')}")  # ! NOCOMMIT
 
     def _get_config_paths(self) -> list[Path]:
         """Parse command line to get config file paths.

--- a/scripts/src/utils/config/config.py
+++ b/scripts/src/utils/config/config.py
@@ -43,7 +43,15 @@ METADATA_IGNORE_FIELDS = (
 VARS_FROM_ENV = (
     "USER_EMAIL",
     "NCBI_API_KEY",
+    "REDIS_HOST",
+    "REDIS_PORT",
+    "REDIS_PASSWORD",
 )
+REDIS_DEFAULTS = {
+    "REDIS_HOST": "localhost",
+    "REDIS_PORT": "6380",
+    "REDIS_PASSWORD": None,
+}
 TEMP_FILES = (
     'entrez_cache_dirname',
 )
@@ -238,7 +246,7 @@ class Config:
             setattr(self, field_name, field_value)
 
         for var in VARS_FROM_ENV:
-            value = os.getenv(var)
+            value = os.getenv(var, REDIS_DEFAULTS.get(var))
             setattr(self, var, value)
 
         self._apply_env_overrides()
@@ -388,6 +396,10 @@ class Config:
     @property
     def throttle_sqlite_global_path(self):
         return self.tempdir / ('throttle_' + self.sqlite_file)
+
+    def REDIS_SSL(self):
+        """Azure Cache for Redis uses SSL on port 6380."""
+        return int(self.REDIS_PORT) == 6380
 
     @property
     def cache_sqlite_path(self):

--- a/scripts/src/utils/config/mappings.py
+++ b/scripts/src/utils/config/mappings.py
@@ -374,6 +374,11 @@ PARAMS = {
         'temp_clean_after_days',
         env_name='TEMP_CLEAN_AFTER_DAYS',
     ),
+    'throttle_backend': StringMapping(
+        'throttle_backend',
+        env_name='THROTTLE_BACKEND',
+        cli_name='throttle-backend',
+    ),
 
     # Analysis criteria (nested in criteria object)
     'alignment_min_nt': IntMapping(

--- a/scripts/src/utils/config/mappings.py
+++ b/scripts/src/utils/config/mappings.py
@@ -257,6 +257,14 @@ PARAMS = {
     ),
 
     # Input metadata
+    'user_email': StringMapping(
+        'user_email',
+        env_name='USER_EMAIL',
+    ),
+    'ncbi_api_key': StringMapping(
+        'ncbi_api_key',
+        env_name='NCBI_API_KEY',
+    ),
     'facility_name': StringMapping(
         'facility_name',
         namespace='inputs',
@@ -378,6 +386,18 @@ PARAMS = {
         'throttle_backend',
         env_name='THROTTLE_BACKEND',
         cli_name='throttle-backend',
+    ),
+    'redis_host': StringMapping(
+        'redis_host',
+        env_name='REDIS_HOST',
+    ),
+    'redis_port': IntMapping(
+        'redis_port',
+        env_name='REDIS_PORT',
+    ),
+    'redis_password': StringMapping(
+        'redis_password',
+        env_name='REDIS_PASSWORD',
     ),
 
     # Analysis criteria (nested in criteria object)

--- a/scripts/src/utils/config/schema.py
+++ b/scripts/src/utils/config/schema.py
@@ -1,5 +1,6 @@
 """Pydantic schema for configuration validation."""
 
+from enum import Enum
 from pathlib import Path
 from typing import Annotated, List
 
@@ -31,6 +32,12 @@ AbsolutePath = Annotated[
     Path,
     AfterValidator(_make_absolute)
 ]
+
+
+class ThrottleBackend(str, Enum):
+    """Enum for throttle backend options."""
+    SQLITE = 'sqlite'
+    REDIS = 'redis'
 
 
 class InputsConfig(BaseModel):
@@ -162,6 +169,15 @@ class ConfigSchema(BaseModel):
         default_factory=lambda: Path('~/.taxonkit').expanduser(),
         description="Path to TaxonKit data directory"
     )
+    throttle_backend: ThrottleBackend = Field(
+        default=ThrottleBackend.SQLITE,
+        description=(
+            "Backend to use for API request throttling. Options are 'local' "
+            "for SQLite-based throttling and 'azure' for Redis-based"
+            " throttling using Azure Cache for Redis. The 'azure' option"
+            " requires additional configuration for Azure credentials and"
+            " cache settings.")
+     )
 
     # Output filenames
     timestamp_filename: str = Field(

--- a/scripts/src/utils/config/schema.py
+++ b/scripts/src/utils/config/schema.py
@@ -169,15 +169,17 @@ class ConfigSchema(BaseModel):
         default_factory=lambda: Path('~/.taxonkit').expanduser(),
         description="Path to TaxonKit data directory"
     )
-    throttle_backend: ThrottleBackend = Field(
-        default=ThrottleBackend.SQLITE,
-        description=(
-            "Backend to use for API request throttling. Options are 'local' "
-            "for SQLite-based throttling and 'azure' for Redis-based"
-            " throttling using Azure Cache for Redis. The 'azure' option"
-            " requires additional configuration for Azure credentials and"
-            " cache settings.")
-     )
+
+    # User details
+    user_email: str | None = Field(
+        default='',
+        description="User email for API access",
+    )
+    ncbi_api_key: str | None = Field(
+        default='',
+        description="NCBI API key for increased rate limits"
+    )
+
 
     # Output filenames
     timestamp_filename: str = Field(
@@ -271,10 +273,7 @@ class ConfigSchema(BaseModel):
         description="GBIF accepted status list"
     )
 
-    # Logging and temporary files
-    log_filename: str = Field(default='run.log', description="Log filename")
-    query_log_filename: str = Field(
-        default='query.log', description="Query log filename")
+    # Caching
     sqlite_file: str = Field(
         default='db.sqlite', description="Throttle SQLite filename")
     entrez_cache_dirname: str = Field(
@@ -303,6 +302,28 @@ class ConfigSchema(BaseModel):
     cache_azure_blob_prefix: str = Field(
         default='',
         description="Optional blob name prefix for all cache entries")
+
+    # Throttle / Redis
+    throttle_backend: ThrottleBackend = Field(
+        default=ThrottleBackend.SQLITE,
+        description=(
+            "Backend to use for API request throttling. Options are 'local' "
+            "for SQLite-based throttling and 'azure' for Redis-based"
+            " throttling using Azure Cache for Redis. The 'azure' option"
+            " requires additional configuration for Azure credentials and"
+            " cache settings.")
+    )
+    redis_host: str = Field(
+        default='localhost', description="Redis host")
+    redis_port: int = Field(
+        default=6379, description="Redis port")
+    redis_password: str | None = Field(
+        default=None, description="Redis password")
+
+    # Logging and temporary files
+    log_filename: str = Field(default='run.log', description="Log filename")
+    query_log_filename: str = Field(
+        default='query.log', description="Query log filename")
     max_api_retries: int = Field(
         default=3, description="Maximum API retries")
     errors_dir: str = Field(default='errors', description="Errors directory")

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -16,7 +16,6 @@ from src.utils import cache
 config = Config()
 logger = logging.getLogger(__name__)
 
-THROTTLE_BACKEND_ENV_VAR = 'THROTTLE_BACKEND'
 MAX_THROTTLE_WAIT_SECONDS = 120
 
 
@@ -488,11 +487,10 @@ BACKENDS = {
 
 def _get_backend() -> AbstractQueueBackend:
     """Select the throttle backend based on environment configuration."""
-    backend_name = os.getenv(THROTTLE_BACKEND_ENV_VAR, 'sqlite').lower()
-    backend_class = BACKENDS.get(backend_name)
+    backend_class = BACKENDS.get(config.throttle_backend)
     if not backend_class:
         raise ValueError(
-            f"Unknown throttle backend '{backend_name}'."
+            f"Unknown throttle backend '{config.throttle_backend}'."
             f" Available backends: {', '.join(BACKENDS.keys())}"
         )
     return backend_class()

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import random
 import sqlite3
 import time
@@ -305,7 +304,6 @@ class SqliteQueueBackend(AbstractQueueBackend):
         if self._await_exception_count >= 5:
             raise exception
 
-
     def _notify_429(self):
         """Record a 429 response and apply backoff if debounce has elapsed.
 
@@ -502,28 +500,16 @@ class Throttle:
     Uses a pluggable backend (SQLite or Redis) to track request timestamps
     and enforce rate limits. The backend is selected via the
     THROTTLE_BACKEND environment variable (default: 'sqlite').
-
-    The endpoint arg should be a dict of:
-        {
-          'requests_per_second': int,  # Max requests per second
-          // AND/OR
-          'requests_per_minute': int,  # Max requests per minute
-          'name': str,                 # Name to identify this endpoint
-        }
     """
 
     def __init__(
         self,
-        endpoint: dict,
+        endpoint: Endpoint,
     ):
-        self.rps = endpoint.get('requests_per_second')
-        self.rpm = endpoint.get('requests_per_minute')
-        if not (self.rps or self.rpm):
-            raise ValueError(
-                "Endpoint must specify either 'requests_per_second' or"
-                " 'requests_per_minute'."
-            )
-        self.name = endpoint['name']
+        self.rps = endpoint.requests_per_second
+        self.rpm = endpoint.requests_per_minute
+        self.name = endpoint.name
+        self.backoff_factor = endpoint.backoff_factor
         self.backend = _get_backend()
         self.backend.initialize(self.name, self.rps, self.rpm)
 
@@ -532,6 +518,10 @@ class Throttle:
 
     def __exit__(self, exc_type, exc_value, traceback):
         pass
+
+    def _notify_429(self):
+        if hasattr(self.backend, '_notify_429'):
+            self.backend._notify_429()
 
     def with_retry(self, func, args=[], kwargs={}, with_cache=False):
         retries = config.max_api_retries

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -23,7 +23,7 @@ class Endpoint:
     """Configuration for a throttled API endpoint."""
 
     name: str
-    requests_per_second: Optional[int] = None
+    requests_per_second: Optional[float] = None
     requests_per_minute: Optional[int] = None
     backoff_factor: Optional[int] = None
     global_rate_limit: bool = False
@@ -45,13 +45,13 @@ class ENDPOINTS:
     )
     GBIF_FAST = Endpoint(
         name='gbif_fast',
-        requests_per_second=10,
+        requests_per_second=5,
         backoff_factor=2,
         global_rate_limit=True,
     )
     ENTREZ = Endpoint(
         name='entrez',
-        requests_per_second=10,
+        requests_per_second=5,
     )
     BOLD = Endpoint(
         name='bold',
@@ -77,13 +77,8 @@ class AbstractQueueBackend(ABC):
     """
 
     @abstractmethod
-    def initialize(
-        self,
-        name: str,
-        rps: int | None,
-        rpm: int | None,
-    ):
-        """Initialize the backend for the given endpoint name."""
+    def initialize(self, endpoint: Endpoint):
+        """Initialize the backend for the given endpoint."""
 
     @abstractmethod
     def acquire(self):
@@ -102,10 +97,8 @@ class SqliteQueueBackend(AbstractQueueBackend):
     _await_exception_count = 0
     _await_exception_msg = ""
 
-    def __init__(
-        self,
-        endpoint: Endpoint,
-    ):
+    def initialize(self, endpoint: Endpoint):
+        """Initialize the SQLite backend for the given endpoint."""
         self.rps = endpoint.requests_per_second
         self.rpm = endpoint.requests_per_minute
         self.per_second_limit = bool(self.rps)
@@ -434,26 +427,32 @@ class RedisQueueBackend(AbstractQueueBackend):
     def __init__(self):
         import redis as redis_lib
         self._connection = redis_lib.Redis(
-            host=config.REDIS_HOST,
-            port=int(config.REDIS_PORT),
-            password=config.REDIS_PASSWORD,
-            ssl=config.REDIS_SSL,
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password,
+            ssl=config.redis_ssl,
+            socket_connect_timeout=10,
+            socket_timeout=10,
         )
         self._user_email = config.user_email or 'ANONYMOUS'
 
-    def initialize(
-        self,
-        name: str,
-        rps: int | None,
-        rpm: int | None,
-    ):
+    def initialize(self, endpoint: Endpoint):
         from limiters import SyncTokenBucket
 
         self._buckets = []
-        key_prefix = f"throttle:{self._user_email}:{name}"
+        key_prefix = f"throttle:{self._user_email}:{endpoint.name}"
 
+        rps = endpoint.requests_per_second
+        if rps and rps < 1:
+            rps_capacity, rps_refill_n = 1, 1 / rps
+        elif rps:
+            rps_capacity, rps_refill_n = int(rps), 1
+        else:
+            rps_capacity, rps_refill_n = None, None
+
+        rpm = endpoint.requests_per_minute
         for key, capacity, refill_n in [
-            ('rps', rps, 1),
+            ('rps', rps_capacity, rps_refill_n),
             ('rpm', rpm, 60),
         ]:
             if capacity:
@@ -511,7 +510,7 @@ class Throttle:
         self.name = endpoint.name
         self.backoff_factor = endpoint.backoff_factor
         self.backend = _get_backend()
-        self.backend.initialize(self.name, self.rps, self.rpm)
+        self.backend.initialize(endpoint)
 
     def __enter__(self):
         self.backend.acquire()

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -534,6 +534,12 @@ class Throttle:
                 )
                 return cached_data
 
+            logger.debug(
+                f"Cache miss for {func.__module__}.{func.__name__} request")
+
+        logger.debug(f"Submitting request to {self.name}: Args: {args},"
+                     f" Kwargs: {kwargs}")
+
         while True:
             try:
                 with self:

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -439,7 +439,7 @@ class RedisQueueBackend(AbstractQueueBackend):
             password=config.REDIS_PASSWORD,
             ssl=config.REDIS_SSL,
         )
-        self._user_email = config.USER_EMAIL or 'ANONYMOUS'
+        self._user_email = config.user_email or 'ANONYMOUS'
 
     def initialize(
         self,

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -466,7 +466,7 @@ class RedisQueueBackend(AbstractQueueBackend):
                     connection=self._connection,
                 ))
 
-        logger.info(
+        logger.debug(
             f"Redis throttle backend initialized for key: {key_prefix}"
         )
 

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -1,8 +1,10 @@
 import logging
+import os
 import random
 import sqlite3
 import time
 from dataclasses import dataclass
+from abc import ABC, abstractmethod
 from pprint import pformat
 from typing import Optional
 
@@ -13,6 +15,9 @@ from src.utils import cache
 
 config = Config()
 logger = logging.getLogger(__name__)
+
+THROTTLE_BACKEND_ENV_VAR = 'THROTTLE_BACKEND'
+MAX_THROTTLE_WAIT_SECONDS = 120
 
 
 @dataclass(frozen=True)
@@ -57,8 +62,8 @@ class ENDPOINTS:
     )
 
 
-class Throttle:
-    """Use SQLite3 database to coordinate throttling of API requests.
+class AbstractQueueBackend(ABC):
+    """Abstract base class for throttle queue backends.
 
     This is necessary to avoid hitting API rate limits, or overwhelming the
     server. Each endpoint (identified by name) is throttled independently to
@@ -67,7 +72,28 @@ class Throttle:
 
     To be conservative, the throttle will limit per-second requests in 2-second
     blocks and per-minute requests in 90-second blocks.
+
+    Backends are responsible for coordinating request timestamps across
+    processes to enforce rate limits. Each backend must support atomic
+    check-and-insert operations to prevent race conditions.
     """
+
+    @abstractmethod
+    def initialize(
+        self,
+        name: str,
+        rps: int | None,
+        rpm: int | None,
+    ):
+        """Initialize the backend for the given endpoint name."""
+
+    @abstractmethod
+    def acquire(self):
+        """Block until a request is allowed, then record it."""
+
+
+class SqliteQueueBackend(AbstractQueueBackend):
+    """SQLite-based throttle backend for single-node concurrency."""
 
     FIELD_NAME = 'timestamp'
     PER_SECOND_BLOCK_MS = 2000
@@ -221,32 +247,24 @@ class Throttle:
             )
         conn.commit()
 
-    def _await_release(self):
-        """Query sqlite DB for permission to send a request.
-
-        The DB table keeps track of requests sent across processes by writing
-        a timestamp for each request sent. This is used to determine if we are
-        within the allowed request limits before sendind the next request.
-        """
+    def acquire(self):
+        """Poll SQLite DB until a request slot is available."""
         started_waiting = time.time()
         while True:
+            if not self.db_path.exists():
+                raise FileNotFoundError(
+                    f"Throttle SQLite DB file not found: {self.db_path}"
+                )
             try:
-                if not self.db_path.exists():
-                    raise FileNotFoundError(
-                        "Throttle SQLite DB file not found:"
-                        f" {self.db_path}"
-                    )
                 with sqlite3.connect(
                     self.db_path,
                     isolation_level=None,
                     timeout=30.0,
                 ) as conn:
                     try:
-                        # Lock the database for writing
                         conn.execute("BEGIN IMMEDIATE")
                         now = int(time.time() * 1000)
                         if self._within_request_limits(now, conn):
-                            # Insert current timestamp atomically
                             conn.execute(
                                 f"INSERT INTO {self.table_name}"
                                 f" ({self.FIELD_NAME})"
@@ -271,13 +289,12 @@ class Throttle:
                     str(e) + f"\nDB path: {self.db_path}"
                 )
 
-            # Sleep for a random interval to reduce race conditions
             time.sleep(round(random.uniform(0.1, 2), 3))
             seconds_waited = int(time.time() - started_waiting)
             if seconds_waited and seconds_waited % 15 == 0:
                 logger.info(
-                    f"Awaiting throttle release for endpoint {self.name}"
-                    f" for >{seconds_waited} seconds..."
+                    f"Awaiting throttle release for endpoint"
+                    f" {self.name} for >{seconds_waited} seconds..."
                 )
 
     def _consider_await_exception(self, exception):
@@ -369,31 +386,26 @@ class Throttle:
         """
         window_start = now - self.window_length_ms
 
-        # Remove expired timestamps older than window length
         conn.execute(
             f"DELETE FROM {self.table_name}"
             f" WHERE {self.FIELD_NAME} < ?",
-            (window_start,))
+            (window_start,),
+        )
 
-        # Count requests in the window
         rps_observed = None
         rpm_observed = None
 
-        if self.per_second_limit:
+        if self.rps:
             args = [
                 f"SELECT COUNT(*) FROM {self.table_name}",
             ]
-            if self.per_minute_limit:
-                # The window is for rpm, so need to narrow
-                # query to RPS window size
+            if self.rpm:
                 args[0] += f" WHERE {self.FIELD_NAME} >= ?"
-                rps_window_start = (
-                    now - self.PER_SECOND_BLOCK_MS
-                )
+                rps_window_start = now - self.PER_SECOND_BLOCK_MS
                 args.append((rps_window_start,))
             rps_observed = conn.execute(*args).fetchone()[0]
 
-        if self.per_minute_limit:
+        if self.rpm:
             rpm_observed = conn.execute(
                 f"SELECT COUNT(*) FROM {self.table_name}"
             ).fetchone()[0]
@@ -413,21 +425,135 @@ class Throttle:
 
         return within_per_second_limit and within_per_minute_limit
 
+
+class RedisQueueBackend(AbstractQueueBackend):
+    """Redis-based throttle backend for distributed multi-node concurrency.
+
+    Uses SyncTokenBucket from redis-rate-limiters for atomic rate
+    limiting with Lua scripts. Supports both per-second and per-minute
+    limits via separate token buckets.
+    """
+
+    def __init__(self):
+        import redis as redis_lib
+        self._connection = redis_lib.Redis(
+            host=config.REDIS_HOST,
+            port=int(config.REDIS_PORT),
+            password=config.REDIS_PASSWORD,
+            ssl=config.REDIS_SSL,
+        )
+        self._user_email = config.USER_EMAIL or 'ANONYMOUS'
+
+    def initialize(
+        self,
+        name: str,
+        rps: int | None,
+        rpm: int | None,
+    ):
+        from limiters import SyncTokenBucket
+
+        self._buckets = []
+        key_prefix = f"throttle:{self._user_email}:{name}"
+
+        for key, capacity, refill_n in [
+            ('rps', rps, 1),
+            ('rpm', rpm, 60),
+        ]:
+            if capacity:
+                self._buckets.append(SyncTokenBucket(
+                    name=f"{key_prefix}:{key}",
+                    capacity=capacity,
+                    refill_frequency=refill_n,
+                    refill_amount=capacity,
+                    max_sleep=MAX_THROTTLE_WAIT_SECONDS,
+                    connection=self._connection,
+                ))
+
+        logger.info(
+            f"Redis throttle backend initialized for key: {key_prefix}"
+        )
+
+    def acquire(self):
+        """Acquire a token from all configured rate limit buckets."""
+        for bucket in self._buckets:
+            with bucket:
+                pass
+
+
+BACKENDS = {
+    'sqlite': SqliteQueueBackend,
+    'redis': RedisQueueBackend,
+}
+
+
+def _get_backend() -> AbstractQueueBackend:
+    """Select the throttle backend based on environment configuration."""
+    backend_name = os.getenv(THROTTLE_BACKEND_ENV_VAR, 'sqlite').lower()
+    backend_class = BACKENDS.get(backend_name)
+    if not backend_class:
+        raise ValueError(
+            f"Unknown throttle backend '{backend_name}'."
+            f" Available backends: {', '.join(BACKENDS.keys())}"
+        )
+    return backend_class()
+
+
+class Throttle:
+    """Coordinate throttling of API requests across processes.
+
+    Uses a pluggable backend (SQLite or Redis) to track request timestamps
+    and enforce rate limits. The backend is selected via the
+    THROTTLE_BACKEND environment variable (default: 'sqlite').
+
+    The endpoint arg should be a dict of:
+        {
+          'requests_per_second': int,  # Max requests per second
+          // AND/OR
+          'requests_per_minute': int,  # Max requests per minute
+          'name': str,                 # Name to identify this endpoint
+        }
+    """
+
+    def __init__(
+        self,
+        endpoint: dict,
+    ):
+        self.rps = endpoint.get('requests_per_second')
+        self.rpm = endpoint.get('requests_per_minute')
+        if not (self.rps or self.rpm):
+            raise ValueError(
+                "Endpoint must specify either 'requests_per_second' or"
+                " 'requests_per_minute'."
+            )
+        self.name = endpoint['name']
+        self.backend = _get_backend()
+        self.backend.initialize(self.name, self.rps, self.rpm)
+
+    def __enter__(self):
+        self.backend.acquire()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
     def with_retry(self, func, args=[], kwargs={}, with_cache=False):
         retries = config.max_api_retries
         if with_cache:
             cache_key = cache.keyhash(func, args, kwargs)
             cached_data = cache.get(cache_key)
             if cached_data is not None:
-                logger.debug(f"Cache hit for {func.__module__}.{func.__name__}"
-                             " request")
+                logger.debug(
+                    f"Cache hit for {func.__module__}.{func.__name__}"
+                    " request"
+                )
                 return cached_data
 
         while True:
             try:
                 with self:
-                    logger.debug("Throttle released. Sending request to"
-                                 f" {self.name}...")
+                    logger.debug(
+                        "Throttle released. Sending request to"
+                        f" {self.name}..."
+                    )
                 res = func(*args, **kwargs)
                 if with_cache:
                     cache.put(cache_key, res)
@@ -453,13 +579,14 @@ class Throttle:
                 elif retries <= 0:
                     raise APIError(
                         'Failed to fetch data from API after'
-                        f' {config.max_api_retries} retries. Please try'
-                        f' resuming this job at a later time.'
+                        f' {config.max_api_retries} retries. Please'
+                        f' try resuming this job at a later time.'
                         f'\nException: {exc}'
                     )
                 logger.warning(
                     "Exception encountered in call to endpoint"
                     f" {self.name} Retrying {retries} more times."
                     f" Exception: {exc}\n"
-                    f" Args:\n{pformat(args)}")
+                    f" Args:\n{pformat(args)}"
+                )
                 time.sleep(sleep_seconds)


### PR DESCRIPTION
[CURRENTLY BEING TESTED]

This PR introduces a Redis backend for coordinated rate-limiting across threads, processses, workflow invocations and compute nodes. If they all share the same Redis server, they will all coordinate their rate limiting.

To enable the Redis backend, the workflow tasks must have access to a Redis server. The following env vars activate this backend:

```
THROTTLE_BACKEND=redis
REDIS_HOST=my-redis-server.com
REDIS_PORT=6379
REDIS_PASSWORD="redis-server-password"
```

If `THROTTLE_BACKEND` is not set, it will default to the original local SQLite3 database backend.
