### PR TITLE
Documenting how to subset blastdb

### DIFF
--- a/bin/extract_accessions.py
+++ b/bin/extract_accessions.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+"""
+Description:
+    Utility script to extract hit accesions from a Taxodactyl pipeline output 
+    blast_result.xml file to be used to create subset database. 
+    See /docs/subset_blastdb.md
+
+Usage:
+    ./extract_accessions.py <path_to_xml> --outdir <destination>
+
+Positional arguments:
+	<path_to_xml>    Path the the input blast_result.xml file.
+	
+Options:
+    -o, --outdir  Path where the list of accessions will be saved (default=pwd).
+"""
+
+import os
+import argparse
+import xml.etree.ElementTree as ET
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "filepath", 
+        help="Path to the blast_result.xml input file."
+    )
+
+    parser.add_argument(
+        "-o", "--outdir", 
+        type=str, 
+        default=os.getcwd(), 
+        help="Path to location to output subset database. (default: pwd)."
+    )
+
+    args = parser.parse_args()
+
+    input_filepath = args.filepath
+    input_filename = os.path.splitext(os.path.basename(input_filepath))[0]
+    output_filename = f"{input_filename}_accessions"
+    output_filepath = os.path.join(args.outdir, output_filename)
+
+    try:
+        input_file = open(input_filepath, mode = "r")
+        tree = ET.parse(input_file)
+        root = tree.getroot()
+        print(f"Scanning {input_filepath} for hit accessions.")
+        hit_accessions = root.findall(".//Hit_accession")
+    except FileNotFoundError:
+        print(f"Error: Input file {input_filepath} not found.")
+    except Exception as e:
+            print(f"Input file error: {input_filepath}, {e}.")
+    else:
+        try:
+            output_file = open(output_filepath, mode = "w")
+        except Exception as e:
+            print(f"Output file error: {output_filepath}, {e}.")
+        else:
+            unique_hits = set()
+            for hit in hit_accessions:
+                output_file.write(hit.text+"\n")
+            print(f"Writing {len(hit_accessions)} hit accessions to {output_filepath}")
+            output_file.close()
+        input_file.close()
+        print("Finished!")
+
+if __name__ == "__main__":
+    main()

--- a/bin/extract_accessions.py
+++ b/bin/extract_accessions.py
@@ -59,7 +59,6 @@ def main():
         except Exception as e:
             print(f"Output file error: {output_filepath}, {e}.")
         else:
-            unique_hits = set()
             for hit in hit_accessions:
                 output_file.write(hit.text+"\n")
             print(f"Writing {len(hit_accessions)} hit accessions to {output_filepath}")

--- a/docs/subset_blastdb.md
+++ b/docs/subset_blastdb.md
@@ -5,9 +5,9 @@ For test purposes, a small BLAST database can be created from the full database 
 
 #### Extract accession IDs
 
-Use `extract_accessions.py` to extract accession IDs from the output `blast_result.xml` for the test case. 
+Use `bin/extract_accessions.py` to extract accession IDs from the output `blast_result.xml` for the test case.
 
-Alternatively, the `accessions.txt` from the `TAXODACTYL:EXTRACT_HITS`  work folder. 
+Alternatively, use the `accessions.txt` file from the `TAXODACTYL:EXTRACT_HITS` work folder.
 
 #### Create `.fasta` of sequences
 

--- a/docs/subset_blastdb.md
+++ b/docs/subset_blastdb.md
@@ -1,0 +1,59 @@
+
+# Creating a subset BLAST database
+
+For test purposes, a small BLAST database can be created from the full database for a test case. It requires that the test case has been run with the database that will be used to subset from. 
+
+## Extract accession IDs
+
+Use `extract_accessions.py` to extract accession IDs from the output `blast_result.xml` for the test case. 
+
+Alternatively, the `accessions.txt` from the `TAXODACTYL:EXTRACT_HITS`  work folder. 
+
+#### Create `.fasta` of sequences
+
+From database directory (`/home/ubuntu/blastdbs/2026-05-12`), do:
+```bash
+blastdbcmd \
+	-db core_nt \ # Name of database
+	-entry_batch /path/to/accessions \
+	-outfmt "%f" \
+	-target_only > test_case_subset_core_nt.fasta
+```
+
+#### Create accession-to-taxid map for the same entries
+
+```bash
+blastdbcmd \
+	-db core_nt \
+	-entry_batch /path/to/accessions \
+	-outfmt "%a %T" \
+	-target_only > test_case_subset_core_nt.taxid_map.tsv
+```
+
+#### Build a new subset BLAST DB 
+
+```bash
+makeblastdb \
+	-in test_case_subset_core_nt.fasta \
+	-dbtype nucl \
+	-parse_seqids \
+	-taxid_map test_case_subset_core_nt.taxid_map.tsv \
+	-out test_case_subset_core_nt
+```
+
+#### Notes
+- This creates a real BLAST DB with only those records.  
+- Keep `-parse_seqids`, otherwise accession lookups by `blastdbcmd` may fail.  
+- Keep `-target_only` when preparing the `.fasta` and `.tsv` so redundant group members are excluded from the list (can result in concatenated headers where lookups fail).
+
+Example accessions file to use for `-entry_batch`:
+```
+KT852368
+KJ085144
+ON754481
+KR476578
+MG469846
+MN549844
+...
+```
+

--- a/docs/subset_blastdb.md
+++ b/docs/subset_blastdb.md
@@ -3,7 +3,7 @@
 
 For test purposes, a small BLAST database can be created from the full database for a test case. It requires that the test case has been run with the database that will be used to subset from. 
 
-## Extract accession IDs
+#### Extract accession IDs
 
 Use `extract_accessions.py` to extract accession IDs from the output `blast_result.xml` for the test case. 
 


### PR DESCRIPTION
Documenting progress towards creating mini databases for test cases that can be packaged for reproducible testing. 

A full script to create a subset database from a test case is in progress, but this pr includes:

1. Documentation how to create a subset database in 4 steps with `/docs/subset_blastdb.md`.

2. Utility script `extract_accessions.py` to extract hit accessions from a `blast_result.xml` output file to use to subset database. 